### PR TITLE
feat: use npx for supabase CLI in type-sync workflow

### DIFF
--- a/.github/workflows/sync-supabase.yml
+++ b/.github/workflows/sync-supabase.yml
@@ -21,12 +21,8 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install Supabase CLI
-        run: npm install -g supabase
-
       - name: Generate Types
-        run: |
-          supabase gen types typescript --project-id ${{ secrets.SUPABASE_PROJECT_ID }} > src/app/types/database.types.ts
+        run: npx supabase gen types typescript --project-id ${{ secrets.SUPABASE_PROJECT_ID }} > src/app/types/database.types.ts
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 


### PR DESCRIPTION
Replace global `npm install -g supabase` with `npx supabase` to avoid unnecessary global installs in the GitHub Actions runner.