### PR TITLE
fix: add Production environment to type-sync workflow

### DIFF
--- a/.github/workflows/sync-supabase.yml
+++ b/.github/workflows/sync-supabase.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-types:
     runs-on: ubuntu-latest
-    # Added permission block to ensure the bot can write back to your repo
+    environment: Production
     permissions:
       contents: write
       


### PR DESCRIPTION
The secrets are scoped to the Production environment, so the job needs environment: Production to access them.