### PR TITLE
fix: rewrite staging-to-main sync workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,20 +5,39 @@ on:
   workflow_dispatch:
 
 jobs:
-  create-pull-request:
+  sync-staging-to-main:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - name: Checkout staging
+      - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          ref: staging
-      - name: Create PR
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }} 
-          base: main
-          branch: sync-staging
-          source_branch: staging
-          title: "sync: merge staging to main"
-          body: |
-            Automated PR to sync changes from stagin to main. Triggered by GitHub Actions.
+          fetch-depth: 0
+
+      - name: Check for diff
+        id: diff
+        run: |
+          git fetch origin main staging
+          if git diff --quiet origin/main..origin/staging; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create or update PR
+        if: steps.diff.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING_PR=$(gh pr list --base main --head staging --json number --jq '.[0].number')
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists"
+          else
+            gh pr create \
+              --base main \
+              --head staging \
+              --title "sync: merge staging to main" \
+              --body "Automated PR to sync changes from staging to main. Triggered by GitHub Actions."
+          fi


### PR DESCRIPTION
Replace peter-evans/create-pull-request (which doesn't support cross-branch PRs) with gh CLI to properly create a PR from staging to main. Skips PR creation if no diff or a PR already exists.