### PR TITLE
feat(browse): Interactive map view for housing browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "jspdf": "^4.2.1",
         "jspdf-autotable": "^5.0.7",
         "lucide-react": "^1.11.0",
+        "maplibre-gl": "^5.24.0",
         "next": "16.2.4",
         "react": "19.2.5",
         "react-dom": "19.2.5",
@@ -792,6 +793,110 @@
       "version": "1.5.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.1"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.0.tgz",
+      "integrity": "sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.8.5",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.5.tgz",
+      "integrity": "sha512-EzEJmMt6thioRH7GI9LWS7ahXTcAhAPGWCe6oTP2Ps4YnsXOOAfeqx854lZaiDnwURfHmcCKV1mr6oo0i23x6w==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.9.tgz",
+      "integrity": "sha512-g/tD8EYJB97udq33ipuJ9a4Q7fcbZnTEnUrgnEc/tLMmEL+zaCbR+X5fkDBO2dgpaAMsLH179qE3UXg2N0Nc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
+      "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@maplibre/geojson-vt": "^5.0.4",
+        "@types/geojson": "^7946.0.16",
+        "@types/supercluster": "^7.1.3",
+        "pbf": "^4.0.1",
+        "supercluster": "^8.0.1"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/@maplibre/geojson-vt": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
+      "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
+      "license": "ISC"
     },
     "node_modules/@next/env": {
       "version": "16.2.4",
@@ -2053,6 +2158,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -2111,6 +2222,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/swagger-ui-react": {
@@ -2657,6 +2777,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.0",
       "dev": true,
@@ -2854,6 +2980,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -3150,6 +3282,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
     "node_modules/jspdf": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
@@ -3175,6 +3313,12 @@
       "peerDependencies": {
         "jspdf": "^2 || ^3 || ^4"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
     },
     "node_modules/lightningcss": {
       "version": "1.31.1",
@@ -3493,6 +3637,40 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/maplibre-gl": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
+      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.1.0",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/geojson-vt": "^6.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.0.2",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3549,6 +3727,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3777,6 +3970,18 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -3824,6 +4029,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -3854,6 +4065,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -3868,6 +4085,12 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
     },
     "node_modules/raf": {
       "version": "3.4.1",
@@ -4104,6 +4327,15 @@
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
     "node_modules/ret": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
@@ -4317,6 +4549,15 @@
         }
       }
     },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
     "node_modules/svg-pathdata": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
@@ -4461,6 +4702,12 @@
       "dependencies": {
         "utrie": "^1.0.2"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/to-buffer": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.7",
     "lucide-react": "^1.11.0",
+    "maplibre-gl": "^5.24.0",
     "next": "16.2.4",
     "react": "19.2.5",
     "react-dom": "19.2.5",

--- a/public/map-style.json
+++ b/public/map-style.json
@@ -1,0 +1,1743 @@
+{
+  "version": 8,
+  "name": "OSM Liberty",
+  "metadata": {
+    "maputnik:license": "https://github.com/maputnik/osm-liberty/blob/gh-pages/LICENSE.md",
+    "maputnik:renderer": "mbgljs",
+    "openmaptiles:version": "3.x"
+  },
+  "sources": {
+    "openmaptiles": {
+      "type": "vector",
+      "url": "https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=B6m4DQknxd9wZ70DnDV4"
+    },
+    "natural_earth_shaded_relief": {
+      "maxzoom": 6,
+      "tileSize": 256,
+      "tiles": [
+        "https://klokantech.github.io/naturalearthtiles/tiles/natural_earth_2_shaded_relief.raster/{z}/{x}/{y}.png"
+      ],
+      "type": "raster"
+    }
+  },
+  "sprite": "https://maputnik.github.io/osm-liberty/sprites/osm-liberty",
+  "glyphs": "https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf",
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {"background-color": "rgb(239,239,239)"}
+    },
+    {
+      "id": "natural_earth",
+      "type": "raster",
+      "source": "natural_earth_shaded_relief",
+      "maxzoom": 6,
+      "paint": {"raster-opacity": {"base": 1.5, "stops": [[0, 0.6], [6, 0.1]]}}
+    },
+    {
+      "id": "park",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "park",
+      "paint": {
+        "fill-color": "#d8e8c8",
+        "fill-opacity": 0.7,
+        "fill-outline-color": "rgba(95, 208, 100, 1)"
+      }
+    },
+    {
+      "id": "park_outline",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "park",
+      "paint": {
+        "line-dasharray": [1, 1.5],
+        "line-color": "rgba(228, 241, 215, 1)"
+      }
+    },
+    {
+      "id": "landuse_residential",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "maxzoom": 8,
+      "filter": ["==", "class", "residential"],
+      "paint": {
+        "fill-color": {
+          "base": 1,
+          "stops": [
+            [9, "hsla(0, 3%, 85%, 0.84)"],
+            [12, "hsla(35, 57%, 88%, 0.49)"]
+          ]
+        }
+      }
+    },
+    {
+      "id": "landcover_wood",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": ["all"],
+      "paint": {
+        "fill-antialias": false,
+        "fill-color": "rgba(103, 206, 116, 0.7)",
+        "fill-opacity": 0.4
+      }
+    },
+    {
+      "id": "landcover_grass",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": ["all", ["==", "class", "grass"]],
+      "paint": {
+        "fill-antialias": false,
+        "fill-color": "rgba(177, 255, 142, 1)",
+        "fill-opacity": 0.3
+      }
+    },
+    {
+      "id": "landcover_ice",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": ["all", ["==", "class", "ice"]],
+      "paint": {
+        "fill-antialias": false,
+        "fill-color": "rgba(224, 236, 236, 1)",
+        "fill-opacity": 0.8
+      }
+    },
+    {
+      "id": "landcover_wetland",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "minzoom": 12,
+      "filter": ["all", ["==", "class", "wetland"]],
+      "paint": {
+        "fill-antialias": true,
+        "fill-opacity": 0.8,
+        "fill-pattern": "wetland_bg_11",
+        "fill-translate-anchor": "map"
+      }
+    },
+    {
+      "id": "landuse_pitch",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "pitch"],
+      "paint": {"fill-color": "rgba(156, 207, 140, 1)"}
+    },
+    {
+      "id": "landuse_track",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "track"],
+      "paint": {"fill-color": "#DEE3CD"}
+    },
+    {
+      "id": "landuse_cemetery",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "cemetery"],
+      "paint": {"fill-color": "hsl(75, 37%, 81%)"}
+    },
+    {
+      "id": "landuse_hospital",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "hospital"],
+      "paint": {"fill-color": "#fde"}
+    },
+    {
+      "id": "landuse_school",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "filter": ["==", "class", "school"],
+      "paint": {"fill-color": "rgb(236,238,204)"}
+    },
+    {
+      "id": "waterway_tunnel",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": ["all", ["==", "brunnel", "tunnel"]],
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-dasharray": [3, 3],
+        "line-gap-width": {"stops": [[12, 0], [20, 6]]},
+        "line-opacity": 1,
+        "line-width": {"base": 1.4, "stops": [[8, 1], [20, 2]]}
+      }
+    },
+    {
+      "id": "waterway_river",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": ["all", ["==", "class", "river"], ["!=", "brunnel", "tunnel"]],
+      "layout": {"line-cap": "round"},
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {"base": 1.2, "stops": [[11, 0.5], [20, 6]]}
+      }
+    },
+    {
+      "id": "waterway_other",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": ["all", ["!=", "class", "river"], ["!=", "brunnel", "tunnel"]],
+      "layout": {"line-cap": "round"},
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {"base": 1.3, "stops": [[13, 0.5], [20, 6]]}
+      }
+    },
+    {
+      "id": "water",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "water",
+      "filter": ["all", ["!=", "brunnel", "tunnel"]],
+      "paint": {"fill-color": "rgba(164, 219, 255, 1)"}
+    },
+    {
+      "id": "landcover_sand",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "filter": ["all", ["==", "class", "sand"]],
+      "paint": {"fill-color": "rgba(247, 239, 195, 1)"}
+    },
+    {
+      "id": "aeroway_fill",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 11,
+      "filter": ["==", "$type", "Polygon"],
+      "paint": {"fill-color": "rgba(229, 228, 224, 1)", "fill-opacity": 0.7}
+    },
+    {
+      "id": "aeroway_runway",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["==", "class", "runway"]
+      ],
+      "paint": {
+        "line-color": "#f0ede9",
+        "line-width": {"base": 1.2, "stops": [[11, 3], [20, 16]]}
+      }
+    },
+    {
+      "id": "aeroway_taxiway",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "minzoom": 11,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["==", "class", "taxiway"]
+      ],
+      "paint": {
+        "line-color": "#f0ede9",
+        "line-width": {"base": 1.2, "stops": [[11, 0.5], [20, 6]]}
+      }
+    },
+    {
+      "id": "tunnel_motorway_link_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "class", "motorway"],
+        ["==", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-dasharray": [0.5, 0.25],
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+        }
+      }
+    },
+    {
+      "id": "tunnel_service_track_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "service", "track"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-dasharray": [0.5, 0.25],
+        "line-width": {"base": 1.2, "stops": [[15, 1], [16, 4], [20, 11]]}
+      }
+    },
+    {
+      "id": "tunnel_link_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "ramp", 1], ["==", "brunnel", "tunnel"]],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+        }
+      }
+    },
+    {
+      "id": "tunnel_street_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "street", "street_limited"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-opacity": {"stops": [[12, 0], [12.5, 1]]},
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 0.5], [13, 1], [14, 4], [20, 15]]
+        }
+      }
+    },
+    {
+      "id": "tunnel_secondary_tertiary_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "secondary", "tertiary"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {"base": 1.2, "stops": [[8, 1.5], [20, 17]]}
+      }
+    },
+    {
+      "id": "tunnel_trunk_primary_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "primary", "trunk"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[5, 0.4], [6, 0.7], [7, 1.75], [20, 22]]
+        }
+      }
+    },
+    {
+      "id": "tunnel_motorway_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-dasharray": [0.5, 0.25],
+        "line-width": {
+          "base": 1.2,
+          "stops": [[5, 0.4], [6, 0.7], [7, 1.75], [20, 22]]
+        }
+      }
+    },
+    {
+      "id": "tunnel_path_pedestrian",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "path", "pedestrian"]
+      ],
+      "paint": {
+        "line-color": "hsl(0, 0%, 100%)",
+        "line-dasharray": [1, 0.75],
+        "line-width": {"base": 1.2, "stops": [[14, 0.5], [20, 10]]}
+      }
+    },
+    {
+      "id": "tunnel_motorway_link",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "class", "motorway"],
+        ["==", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+        }
+      }
+    },
+    {
+      "id": "tunnel_service_track",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "service", "track"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {"base": 1.2, "stops": [[15.5, 0], [16, 2], [20, 7.5]]}
+      }
+    },
+    {
+      "id": "tunnel_link",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "ramp", 1], ["==", "brunnel", "tunnel"]],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fff4c6",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+        }
+      }
+    },
+    {
+      "id": "tunnel_minor",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "brunnel", "tunnel"], ["in", "class", "minor"]],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {"base": 1.2, "stops": [[13.5, 0], [14, 2.5], [20, 11.5]]}
+      }
+    },
+    {
+      "id": "tunnel_secondary_tertiary",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "secondary", "tertiary"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fff4c6",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 10]]}
+      }
+    },
+    {
+      "id": "tunnel_trunk_primary",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "primary", "trunk"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fff4c6",
+        "line-width": {"base": 1.2, "stops": [[5, 0], [7, 1], [20, 18]]}
+      }
+    },
+    {
+      "id": "tunnel_motorway",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#ffdaa6",
+        "line-width": {"base": 1.2, "stops": [[5, 0], [7, 1], [20, 18]]}
+      }
+    },
+    {
+      "id": "tunnel_major_rail",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "brunnel", "tunnel"], ["in", "class", "rail"]],
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {"base": 1.4, "stops": [[14, 0.4], [15, 0.75], [20, 2]]}
+      }
+    },
+    {
+      "id": "tunnel_major_rail_hatching",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "brunnel", "tunnel"], ["==", "class", "rail"]],
+      "paint": {
+        "line-color": "#bbb",
+        "line-dasharray": [0.2, 8],
+        "line-width": {"base": 1.4, "stops": [[14.5, 0], [15, 3], [20, 8]]}
+      }
+    },
+    {
+      "id": "tunnel_transit_rail",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["in", "class", "transit"]
+      ],
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {"base": 1.4, "stops": [[14, 0.4], [15, 0.75], [20, 2]]}
+      }
+    },
+    {
+      "id": "tunnel_transit_rail_hatching",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "tunnel"],
+        ["==", "class", "transit"]
+      ],
+      "paint": {
+        "line-color": "#bbb",
+        "line-dasharray": [0.2, 8],
+        "line-width": {"base": 1.4, "stops": [[14.5, 0], [15, 3], [20, 8]]}
+      }
+    },
+    {
+      "id": "road_area_pattern",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "$type", "Polygon"]],
+      "paint": {"fill-pattern": "pedestrian_polygon"}
+    },
+    {
+      "id": "road_motorway_link_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "motorway"],
+        ["==", "ramp", 1]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+        }
+      }
+    },
+    {
+      "id": "road_service_track_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "service", "track"]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-width": {"base": 1.2, "stops": [[15, 1], [16, 4], [20, 11]]}
+      }
+    },
+    {
+      "id": "road_link_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["!in", "class", "pedestrian", "path", "track", "service", "motorway"],
+        ["==", "ramp", 1]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+        }
+      }
+    },
+    {
+      "id": "road_minor_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "minor"],
+        ["!=", "ramp", 1]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-opacity": {"stops": [[12, 0], [12.5, 1]]},
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 0.5], [13, 1], [14, 4], [20, 20]]
+        }
+      }
+    },
+    {
+      "id": "road_secondary_tertiary_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "secondary", "tertiary"],
+        ["!=", "ramp", 1]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "rgba(143, 143, 143, 1)",
+        "line-width": {"base": 1.2, "stops": [[8, 1.5], [20, 17]]}
+      }
+    },
+    {
+      "id": "road_trunk_primary_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "primary", "trunk"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[5, 0.4], [6, 0.7], [7, 1.75], [20, 22]]
+        }
+      }
+    },
+    {
+      "id": "road_motorway_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[5, 0.4], [6, 0.7], [7, 1.75], [20, 22]]
+        }
+      }
+    },
+    {
+      "id": "road_path_pedestrian",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "path", "pedestrian"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "rgba(218, 191, 191, 0.7)",
+        "line-dasharray": [1, 0.7],
+        "line-width": {"base": 1.2, "stops": [[14, 1], [20, 10]]}
+      }
+    },
+    {
+      "id": "road_motorway_link",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "motorway"],
+        ["==", "ramp", 1]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+        }
+      }
+    },
+    {
+      "id": "road_service_track",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "service", "track"]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {"base": 1.2, "stops": [[15.5, 0], [16, 2], [20, 7.5]]}
+      }
+    },
+    {
+      "id": "road_link",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "ramp", 1],
+        ["!in", "class", "pedestrian", "path", "track", "service", "motorway"]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+        }
+      }
+    },
+    {
+      "id": "road_minor",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "minor"]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {"base": 1.2, "stops": [[13.5, 0], [14, 2.5], [20, 18]]}
+      }
+    },
+    {
+      "id": "road_secondary_tertiary",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "secondary", "tertiary"]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "rgba(220, 220, 220, 1)",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [8, 0.5], [20, 13]]}
+      }
+    },
+    {
+      "id": "road_trunk_primary",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["in", "class", "primary", "trunk"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {"base": 1.2, "stops": [[5, 0], [7, 1], [20, 18]]}
+      }
+    },
+    {
+      "id": "road_motorway",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 5,
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1]
+      ],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": {
+          "base": 1,
+          "stops": [[5, "hsl(26, 87%, 62%)"], [6, "#fc8"]]
+        },
+        "line-width": {"base": 1.2, "stops": [[5, 0], [7, 1], [20, 18]]}
+      }
+    },
+    {
+      "id": "road_major_rail",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "rail"]
+      ],
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {"base": 1.4, "stops": [[14, 0.4], [15, 0.75], [20, 2]]}
+      }
+    },
+    {
+      "id": "road_major_rail_hatching",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "rail"]
+      ],
+      "paint": {
+        "line-color": "#bbb",
+        "line-dasharray": [0.2, 8],
+        "line-width": {"base": 1.4, "stops": [[14.5, 0], [15, 3], [20, 8]]}
+      }
+    },
+    {
+      "id": "road_transit_rail",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "transit"]
+      ],
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {"base": 1.4, "stops": [[14, 0.4], [15, 0.75], [20, 2]]}
+      }
+    },
+    {
+      "id": "road_transit_rail_hatching",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["!in", "brunnel", "bridge", "tunnel"],
+        ["==", "class", "transit"]
+      ],
+      "paint": {
+        "line-color": "#bbb",
+        "line-dasharray": [0.2, 8],
+        "line-width": {"base": 1.4, "stops": [[14.5, 0], [15, 3], [20, 8]]}
+      }
+    },
+    {
+      "id": "road_one_way_arrow",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 16,
+      "filter": ["==", "oneway", 1],
+      "layout": {"icon-image": "arrow", "symbol-placement": "line"}
+    },
+    {
+      "id": "road_one_way_arrow_opposite",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "minzoom": 16,
+      "filter": ["==", "oneway", -1],
+      "layout": {
+        "icon-image": "arrow",
+        "symbol-placement": "line",
+        "icon-rotate": 180
+      }
+    },
+    {
+      "id": "bridge_motorway_link_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "class", "motorway"],
+        ["==", "ramp", 1],
+        ["==", "brunnel", "bridge"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+        }
+      }
+    },
+    {
+      "id": "bridge_service_track_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "service", "track"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-width": {"base": 1.2, "stops": [[15, 1], [16, 4], [20, 11]]}
+      }
+    },
+    {
+      "id": "bridge_link_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "class", "link"], ["==", "brunnel", "bridge"]],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 1], [13, 3], [14, 4], [20, 15]]
+        }
+      }
+    },
+    {
+      "id": "bridge_street_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "street", "street_limited"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "hsl(36, 6%, 74%)",
+        "line-opacity": {"stops": [[12, 0], [12.5, 1]]},
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12, 0.5], [13, 1], [14, 4], [20, 25]]
+        }
+      }
+    },
+    {
+      "id": "bridge_path_pedestrian_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "path", "pedestrian"]
+      ],
+      "paint": {
+        "line-color": "hsl(35, 6%, 80%)",
+        "line-dasharray": [1, 0],
+        "line-width": {"base": 1.2, "stops": [[14, 1.5], [20, 18]]}
+      }
+    },
+    {
+      "id": "bridge_secondary_tertiary_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "secondary", "tertiary"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {"base": 1.2, "stops": [[8, 1.5], [20, 17]]}
+      }
+    },
+    {
+      "id": "bridge_trunk_primary_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "primary", "trunk"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[5, 0.4], [6, 0.7], [7, 1.75], [20, 22]]
+        }
+      }
+    },
+    {
+      "id": "bridge_motorway_casing",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "bridge"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[5, 0.4], [6, 0.7], [7, 1.75], [20, 22]]
+        }
+      }
+    },
+    {
+      "id": "bridge_path_pedestrian",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "$type", "LineString"],
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "path", "pedestrian"]
+      ],
+      "paint": {
+        "line-color": "hsl(0, 0%, 100%)",
+        "line-dasharray": [1, 0.3],
+        "line-width": {"base": 1.2, "stops": [[14, 0.5], [20, 10]]}
+      }
+    },
+    {
+      "id": "bridge_motorway_link",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "class", "motorway"],
+        ["==", "ramp", 1],
+        ["==", "brunnel", "bridge"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+        }
+      }
+    },
+    {
+      "id": "bridge_service_track",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "service", "track"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {"base": 1.2, "stops": [[15.5, 0], [16, 2], [20, 7.5]]}
+      }
+    },
+    {
+      "id": "bridge_link",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "class", "link"], ["==", "brunnel", "bridge"]],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [[12.5, 0], [13, 1.5], [14, 2.5], [20, 11.5]]
+        }
+      }
+    },
+    {
+      "id": "bridge_street",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "brunnel", "bridge"], ["in", "class", "minor"]],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {"base": 1.2, "stops": [[13.5, 0], [14, 2.5], [20, 18]]}
+      }
+    },
+    {
+      "id": "bridge_secondary_tertiary",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "secondary", "tertiary"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {"base": 1.2, "stops": [[6.5, 0], [7, 0.5], [20, 10]]}
+      }
+    },
+    {
+      "id": "bridge_trunk_primary",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "brunnel", "bridge"],
+        ["in", "class", "primary", "trunk"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {"base": 1.2, "stops": [[5, 0], [7, 1], [20, 18]]}
+      }
+    },
+    {
+      "id": "bridge_motorway",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "bridge"]
+      ],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {"base": 1.2, "stops": [[5, 0], [7, 1], [20, 18]]}
+      }
+    },
+    {
+      "id": "bridge_major_rail",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "bridge"]],
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {"base": 1.4, "stops": [[14, 0.4], [15, 0.75], [20, 2]]}
+      }
+    },
+    {
+      "id": "bridge_major_rail_hatching",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "bridge"]],
+      "paint": {
+        "line-color": "#bbb",
+        "line-dasharray": [0.2, 8],
+        "line-width": {"base": 1.4, "stops": [[14.5, 0], [15, 3], [20, 8]]}
+      }
+    },
+    {
+      "id": "bridge_transit_rail",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "class", "transit"],
+        ["==", "brunnel", "bridge"]
+      ],
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {"base": 1.4, "stops": [[14, 0.4], [15, 0.75], [20, 2]]}
+      }
+    },
+    {
+      "id": "bridge_transit_rail_hatching",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        ["==", "class", "transit"],
+        ["==", "brunnel", "bridge"]
+      ],
+      "paint": {
+        "line-color": "#bbb",
+        "line-dasharray": [0.2, 8],
+        "line-width": {"base": 1.4, "stops": [[14.5, 0], [15, 3], [20, 8]]}
+      }
+    },
+    {
+      "id": "building",
+      "type": "fill",
+      "source": "openmaptiles",
+      "source-layer": "building",
+      "minzoom": 13,
+      "maxzoom": 14,
+      "paint": {
+        "fill-color": "hsl(35, 8%, 85%)",
+        "fill-outline-color": {
+          "base": 1,
+          "stops": [[13, "hsla(35, 6%, 79%, 0.32)"], [14, "hsl(35, 6%, 79%)"]]
+        }
+      }
+    },
+    {
+      "id": "building-3d",
+      "type": "fill-extrusion",
+      "source": "openmaptiles",
+      "source-layer": "building",
+      "minzoom": 14,
+      "paint": {
+        "fill-extrusion-color": "rgba(247, 242, 235, 1)",
+        "fill-extrusion-height": {
+          "property": "render_height",
+          "type": "identity"
+        },
+        "fill-extrusion-base": {
+          "property": "render_min_height",
+          "type": "identity"
+        },
+        "fill-extrusion-opacity": 0.8
+      }
+    },
+    {
+      "id": "boundary_3",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "minzoom": 8,
+      "filter": ["all", ["in", "admin_level", 3, 4]],
+      "layout": {"line-join": "round"},
+      "paint": {
+        "line-color": "#9e9cab",
+        "line-dasharray": [5, 1],
+        "line-width": {"base": 1, "stops": [[4, 0.4], [5, 1], [12, 1.8]]}
+      }
+    },
+    {
+      "id": "boundary_2_z0-4",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "maxzoom": 5,
+      "filter": ["all", ["==", "admin_level", 2], ["!has", "claimed_by"]],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "hsl(248, 1%, 41%)",
+        "line-opacity": {"base": 1, "stops": [[0, 0.4], [4, 1]]},
+        "line-width": {"base": 1, "stops": [[3, 1], [5, 1.2], [12, 3]]}
+      }
+    },
+    {
+      "id": "boundary_2_z5-",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "minzoom": 5,
+      "filter": ["all", ["==", "admin_level", 2]],
+      "layout": {"line-cap": "round", "line-join": "round"},
+      "paint": {
+        "line-color": "hsl(248, 1%, 41%)",
+        "line-opacity": {"base": 1, "stops": [[0, 0.4], [4, 1]]},
+        "line-width": {"base": 1, "stops": [[3, 1], [5, 1.2], [12, 3]]}
+      }
+    },
+    {
+      "id": "water_name_line",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "filter": ["all", ["==", "$type", "LineString"]],
+      "layout": {
+        "text-field": "{name}",
+        "text-font": ["Roboto Regular"],
+        "text-max-width": 5,
+        "text-size": 12,
+        "symbol-placement": "line"
+      },
+      "paint": {
+        "text-color": "#5d60be",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "water_name_point",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "water_name",
+      "filter": ["==", "$type", "Point"],
+      "layout": {
+        "text-field": "{name}",
+        "text-font": ["Roboto Regular"],
+        "text-max-width": 5,
+        "text-size": 12
+      },
+      "paint": {
+        "text-color": "#5d60be",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "poi_z16",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "minzoom": 16,
+      "filter": ["all", ["==", "$type", "Point"], [">=", "rank", 20]],
+      "layout": {
+        "icon-image": [
+          "match",
+          ["get", "subclass"],
+          ["florist", "furniture", "soccer", "tennis"],
+          ["get", "subclass"],
+          ["get", "class"]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": ["Roboto Condensed Italic"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 12
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "poi_z15",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "minzoom": 15,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        [">=", "rank", 7],
+        ["<", "rank", 20]
+      ],
+      "layout": {
+        "icon-image": [
+          "match",
+          ["get", "subclass"],
+          ["florist", "furniture", "soccer", "tennis"],
+          ["get", "subclass"],
+          ["get", "class"]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": ["Roboto Condensed Italic"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 12
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "poi_z14",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "filter": [
+        "all",
+        ["==", "$type", "Point"],
+        [">=", "rank", 1],
+        ["<", "rank", 7]
+      ],
+      "layout": {
+        "icon-image": [
+          "match",
+          ["get", "subclass"],
+          ["florist", "furniture", "soccer", "tennis"],
+          ["get", "subclass"],
+          ["get", "class"]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": ["Roboto Condensed Italic"],
+        "text-max-width": 9,
+        "text-offset": [0, 0.6],
+        "text-size": 12
+      },
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "poi_transit",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "filter": ["all", ["in", "class", "bus", "rail", "airport"]],
+      "layout": {
+        "icon-image": "{class}",
+        "text-anchor": "left",
+        "text-field": "{name_en}",
+        "text-font": ["Roboto Condensed Italic"],
+        "text-max-width": 9,
+        "text-offset": [0.9, 0],
+        "text-size": 12
+      },
+      "paint": {
+        "text-color": "#4898ff",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "road_label",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "filter": ["all"],
+      "layout": {
+        "symbol-placement": "line",
+        "text-anchor": "center",
+        "text-field": "{name}",
+        "text-font": ["Roboto Regular"],
+        "text-offset": [0, 0.15],
+        "text-size": {"base": 1, "stops": [[13, 12], [14, 13]]}
+      },
+      "paint": {
+        "text-color": "#765",
+        "text-halo-blur": 0.5,
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "road_shield",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "transportation_name",
+      "minzoom": 7,
+      "filter": ["all", ["<=", "ref_length", 6]],
+      "layout": {
+        "icon-image": "default_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "symbol-placement": {"base": 1, "stops": [[10, "point"], [11, "line"]]},
+        "symbol-spacing": 500,
+        "text-field": "{ref}",
+        "text-font": ["Roboto Regular"],
+        "text-offset": [0, 0.1],
+        "text-rotation-alignment": "viewport",
+        "text-size": 10,
+        "icon-size": 0.8
+      }
+    },
+    {
+      "id": "place_other",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "hamlet",
+          "island",
+          "islet",
+          "neighbourhood",
+          "suburb",
+          "quarter"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name_en}",
+        "text-font": ["Roboto Condensed Italic"],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 9,
+        "text-size": {"base": 1.2, "stops": [[12, 10], [15, 14]]},
+        "text-transform": "uppercase"
+      },
+      "paint": {
+        "text-color": "#633",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_village",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": ["all", ["==", "class", "village"]],
+      "layout": {
+        "text-field": "{name_en}",
+        "text-font": ["Roboto Regular"],
+        "text-max-width": 8,
+        "text-size": {"base": 1.2, "stops": [[10, 12], [15, 22]]}
+      },
+      "paint": {
+        "text-color": "#333",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_town",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": ["all", ["==", "class", "town"]],
+      "layout": {
+        "icon-image": {"base": 1, "stops": [[0, "dot_9"], [8, ""]]},
+        "text-anchor": "bottom",
+        "text-field": "{name_en}",
+        "text-font": ["Roboto Regular"],
+        "text-max-width": 8,
+        "text-offset": [0, 0],
+        "text-size": {"base": 1.2, "stops": [[7, 12], [11, 16]]}
+      },
+      "paint": {
+        "text-color": "#333",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "place_city",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "minzoom": 5,
+      "filter": ["all", ["==", "class", "city"]],
+      "layout": {
+        "icon-image": {"base": 1, "stops": [[0, "dot_9"], [8, ""]]},
+        "text-anchor": "bottom",
+        "text-field": "{name_en}",
+        "text-font": ["Roboto Medium"],
+        "text-max-width": 8,
+        "text-offset": [0, 0],
+        "text-size": {"base": 1.2, "stops": [[7, 14], [11, 24]]},
+        "icon-allow-overlap": true,
+        "icon-optional": false
+      },
+      "paint": {
+        "text-color": "#333",
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "state",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 6,
+      "filter": ["all", ["==", "class", "state"]],
+      "layout": {
+        "text-field": "{name_en}",
+        "text-font": ["Roboto Condensed Italic"],
+        "text-size": {"stops": [[4, 11], [6, 15]]},
+        "text-transform": "uppercase"
+      },
+      "paint": {
+        "text-color": "#633",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "country_3",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": ["all", [">=", "rank", 3], ["==", "class", "country"]],
+      "layout": {
+        "text-field": "{name_en}",
+        "text-font": ["Roboto Condensed Italic"],
+        "text-max-width": 6.25,
+        "text-size": {"stops": [[3, 11], [7, 17]]},
+        "text-transform": "none"
+      },
+      "paint": {
+        "text-color": "#334",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "country_2",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": ["all", ["==", "rank", 2], ["==", "class", "country"]],
+      "layout": {
+        "text-field": "{name_en}",
+        "text-font": ["Roboto Condensed Italic"],
+        "text-max-width": 6.25,
+        "text-size": {"stops": [[2, 11], [5, 17]]},
+        "text-transform": "none"
+      },
+      "paint": {
+        "text-color": "#334",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "country_1",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "filter": ["all", ["==", "rank", 1], ["==", "class", "country"]],
+      "layout": {
+        "text-field": "{name_en}",
+        "text-font": ["Roboto Condensed Italic"],
+        "text-max-width": 6.25,
+        "text-size": {"stops": [[1, 11], [4, 17]]},
+        "text-transform": "none"
+      },
+      "paint": {
+        "text-color": "#334",
+        "text-halo-blur": 1,
+        "text-halo-color": "rgba(255,255,255,0.8)",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "continent",
+      "type": "symbol",
+      "source": "openmaptiles",
+      "source-layer": "place",
+      "maxzoom": 1,
+      "filter": ["all", ["==", "class", "continent"]],
+      "layout": {
+        "text-field": "{name_en}",
+        "text-font": ["Roboto Condensed Italic"],
+        "text-size": 13,
+        "text-transform": "uppercase",
+        "text-justify": "center"
+      },
+      "paint": {
+        "text-color": "#633",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1
+      }
+    }
+  ],
+  "id": "osm-liberty"
+}

--- a/src/app/(main)/admin/accommodations/AdminAccommodationsContent.tsx
+++ b/src/app/(main)/admin/accommodations/AdminAccommodationsContent.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Map, LayoutGrid } from "lucide-react";
+import HousingMap, { type HousingMarker } from "@/app/components/map/HousingMap";
+import DormCard from "@/app/components/admin/dorm_card";
+
+type DormCardData = {
+  housingId: string;
+  housingIdNum: number;
+  name: string;
+  address: string;
+  totalRooms: number;
+  occupiedRooms: number;
+  vacantRooms: number;
+  occupancyRate: number;
+  minRent: number;
+  managerAccountNumber: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  image: string | null;
+  housingType: string;
+};
+
+export default function AdminAccommodationsContent({
+  dormCards,
+}: {
+  dormCards: DormCardData[];
+}) {
+  const [showMap, setShowMap] = useState(false);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const markers: HousingMarker[] = useMemo(
+    () =>
+      dormCards
+        .filter((d) => d.latitude && d.longitude)
+        .map((d) => ({
+          id: d.housingIdNum,
+          name: d.name,
+          type: d.housingType,
+          price: d.minRent,
+          lat: d.latitude!,
+          lng: d.longitude!,
+          image: d.image,
+        })),
+    [dormCards]
+  );
+
+  return (
+    <>
+      {markers.length > 0 && (
+        <div className="w-full max-w-6xl mx-auto flex justify-end mb-4">
+          <button
+            onClick={() => setShowMap(!showMap)}
+            className="flex items-center gap-2 px-4 py-2 rounded-full bg-[#1C2632] text-white text-sm font-semibold hover:opacity-90 transition shadow-md"
+          >
+            {showMap ? <LayoutGrid size={16} /> : <Map size={16} />}
+            {showMap ? "Hide Map" : "Show Map"}
+          </button>
+        </div>
+      )}
+
+      {showMap && markers.length > 0 && (
+        <div className="w-full max-w-6xl mx-auto mb-6">
+          <div className="w-full rounded-xl overflow-hidden shadow-lg" style={{ height: "400px" }}>
+            <HousingMap
+              housings={markers}
+              selectedId={selectedId}
+              onMarkerClick={(id) => setSelectedId(id)}
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 w-full max-w-6xl mx-auto">
+        {dormCards.length === 0 ? (
+          <div className="w-full max-w-6xl mx-auto rounded-2xl border border-[#CEC7B0] bg-white px-8 py-14 text-center text-[#1C2632] shadow-sm">
+            <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-[#EDE9DE] text-[#8AABAC]">
+              0
+            </div>
+            <div className="text-lg font-semibold">No properties found</div>
+            <div className="mt-2 text-sm text-[#8AABAC]">
+              Property cards will appear here once housing records are available.
+            </div>
+          </div>
+        ) : (
+          dormCards.map((housing) => (
+            <DormCard key={housing.housingId} {...housing} />
+          ))
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/app/(main)/admin/accommodations/page.tsx
+++ b/src/app/(main)/admin/accommodations/page.tsx
@@ -5,25 +5,9 @@ export const metadata: Metadata = {
   description: "View and manage all housings for managed properties",
 };
 
-import DormCard from "@/app/components/admin/dorm_card";
 import { housingData } from "@/lib/data/housing-data";
 import StateMessage from "@/app/components/ui/state-message";
-
-// NOTE: This page is now a server component, for fast async data fetching
-// For interactivity (e.g. useState), import client components
-function EmptyPropertiesState() {
-  return (
-    <div className="w-full max-w-6xl mx-auto rounded-2xl border border-[#CEC7B0] bg-white px-8 py-14 text-center text-[#1C2632] shadow-sm">
-      <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-[#EDE9DE] text-[#8AABAC]">
-        0
-      </div>
-      <div className="text-lg font-semibold">No properties found</div>
-      <div className="mt-2 text-sm text-[#8AABAC]">
-        Property cards will appear here once housing records are available.
-      </div>
-    </div>
-  );
-}
+import AdminAccommodationsContent from "./AdminAccommodationsContent";
 
 export default async function Page() {
   let liveDormCards: Awaited<
@@ -43,15 +27,7 @@ export default async function Page() {
   return (
     <main className="min-h-screen text-white flex flex-col items-center p-6">
       <section className="w-full mb-12">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 w-full max-w-6xl mx-auto">
-          {liveDormCards.length === 0 ? (
-            <EmptyPropertiesState />
-          ) : (
-            liveDormCards.map((housing) => (
-              <DormCard key={housing.housingId} {...housing} />
-            ))
-          )}
-        </div>
+        <AdminAccommodationsContent dormCards={liveDormCards} />
       </section>
     </main>
   );

--- a/src/app/(main)/manage/accommodations/AccommodationsPage.tsx
+++ b/src/app/(main)/manage/accommodations/AccommodationsPage.tsx
@@ -2,7 +2,8 @@
 
 import Link from "next/link";
 import { useState, useMemo } from "react";
-import { Search, SlidersHorizontal } from "lucide-react";
+import { Search, SlidersHorizontal, Map, LayoutGrid } from "lucide-react";
+import HousingMap, { type HousingMarker } from "@/app/components/map/HousingMap";
 
 import type { Database } from "@/app/types/database.types";
 
@@ -150,6 +151,24 @@ export default function AccommodationsPage({
 }) {
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<SortOption>("name-asc");
+  const [showMap, setShowMap] = useState(false);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const markers: HousingMarker[] = useMemo(
+    () =>
+      housings
+        .filter((h) => h.latitude && h.longitude)
+        .map((h) => ({
+          id: h.housing_id,
+          name: h.housing_name,
+          type: h.housing_type,
+          price: h.rent_price,
+          lat: h.latitude!,
+          lng: h.longitude!,
+          image: h.housing_image,
+        })),
+    [housings]
+  );
 
   const filtered = useMemo(() => {
     let result = [...housings];
@@ -198,9 +217,20 @@ export default function AccommodationsPage({
   return (
     <main className="min-h-screen flex flex-col p-6 gap-6 bg-[var(--cream)]">
       <section className="flex flex-col gap-4 px-5">
-        <h1 className="text-3xl text-[var(--dark-orange)] font-semibold">
-          Accommodations
-        </h1>
+        <div className="flex items-center justify-between">
+          <h1 className="text-3xl text-[var(--dark-orange)] font-semibold">
+            Accommodations
+          </h1>
+          {markers.length > 0 && (
+            <button
+              onClick={() => setShowMap(!showMap)}
+              className="flex items-center gap-2 px-4 py-2 rounded-full bg-[var(--dark-blue)] text-white text-sm font-semibold hover:opacity-90 transition shadow-md"
+            >
+              {showMap ? <LayoutGrid size={16} /> : <Map size={16} />}
+              {showMap ? "Hide Map" : "Show Map"}
+            </button>
+          )}
+        </div>
         <FilterBar
           search={search}
           onSearchChange={setSearch}
@@ -209,6 +239,19 @@ export default function AccommodationsPage({
           resultCount={filtered.length}
         />
       </section>
+
+      {showMap && markers.length > 0 && (
+        <section className="px-5">
+          <div className="w-full rounded-xl overflow-hidden shadow-lg" style={{ height: "400px" }}>
+            <HousingMap
+              housings={markers}
+              selectedId={selectedId}
+              onMarkerClick={(id) => setSelectedId(id)}
+            />
+          </div>
+        </section>
+      )}
+
       <section className="px-5 overflow-x-auto">
         {filtered.length === 0 ? (
           <p className="text-gray-500">No accommodations found.</p>

--- a/src/app/(main)/student/browse/_components/BrowseContent.tsx
+++ b/src/app/(main)/student/browse/_components/BrowseContent.tsx
@@ -203,6 +203,7 @@ export default function BrowseContent({
         .browse-map-panel {
           width: 100%;
           height: 45vh;
+          min-height: 280px;
           position: relative;
         }
 
@@ -280,33 +281,32 @@ export default function BrowseContent({
         }
 
         /* ═══════════════════════════════════════
-           DESKTOP: Full-bleed split layout
+           DESKTOP: Map fixed left, content right
            ═══════════════════════════════════════ */
 
         @media (min-width: 1024px) {
           .browse-root.map-visible {
-            display: grid;
-            grid-template-columns: 50% 50%;
-            height: calc(100vh - 5.5rem);
-            overflow: hidden;
+            position: relative;
           }
 
+          /* Map: pinned to left half of viewport, never stretches */
           .browse-map-panel {
-            height: 100%;
-            position: sticky;
-            top: 0;
+            position: fixed;
+            top: 5.5rem; /* below navbar + breadcrumb */
+            left: 0;
+            width: 50%;
+            height: calc(100vh - 5.5rem);
+            z-index: 2;
           }
 
+          /* Content: offset to right half */
           .browse-content-panel {
-            height: 100%;
-            overflow: hidden;
-            display: flex;
-            flex-direction: column;
+            margin-left: 50%;
+            width: 50%;
+            min-height: calc(100vh - 5.5rem);
           }
 
           .browse-cards-scroll {
-            flex: 1;
-            overflow-y: auto;
             padding: 1rem 1.5rem 2rem;
           }
 
@@ -335,8 +335,13 @@ export default function BrowseContent({
         }
 
         @media (min-width: 1440px) {
-          .browse-root.map-visible {
-            grid-template-columns: 55% 45%;
+          .browse-map-panel {
+            width: 55%;
+          }
+
+          .browse-root.map-visible .browse-content-panel {
+            margin-left: 55%;
+            width: 45%;
           }
 
           .browse-cards-grid {

--- a/src/app/(main)/student/browse/_components/BrowseContent.tsx
+++ b/src/app/(main)/student/browse/_components/BrowseContent.tsx
@@ -283,32 +283,35 @@ export default function BrowseContent({
         }
 
         /* ═══════════════════════════════════════
-           DESKTOP: Map fixed left, content right
+           DESKTOP: Flex split, map doesn't scroll
            ═══════════════════════════════════════ */
 
         @media (min-width: 1024px) {
           .browse-root.map-visible {
-            position: relative;
-          }
-
-          /* Map: pinned to left half of viewport, never stretches */
-          .browse-map-panel {
-            position: fixed;
-            top: 5.5rem; /* below navbar + breadcrumb */
-            left: 0;
-            width: 50%;
+            display: flex;
+            flex-direction: row;
             height: calc(100vh - 5.5rem);
-            z-index: 2;
+            overflow: hidden;
           }
 
-          /* Content: offset to right half */
-          .browse-content-panel {
-            margin-left: 50%;
+          .browse-map-panel {
             width: 50%;
-            min-height: calc(100vh - 5.5rem);
+            height: 100%;
+            flex-shrink: 0;
+            overflow: hidden;
+          }
+
+          .browse-content-panel {
+            width: 50%;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
           }
 
           .browse-cards-scroll {
+            flex: 1;
+            overflow-y: auto;
             padding: 1rem 1.5rem 2rem;
           }
 
@@ -342,7 +345,6 @@ export default function BrowseContent({
           }
 
           .browse-root.map-visible .browse-content-panel {
-            margin-left: 55%;
             width: 45%;
           }
 

--- a/src/app/(main)/student/browse/_components/BrowseContent.tsx
+++ b/src/app/(main)/student/browse/_components/BrowseContent.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, type ReactNode } from "react";
 import Image from "next/image";
-import HousingMap, { type HousingMarker } from "./HousingMap";
+import HousingMap, { type HousingMarker } from "@/app/components/map/HousingMap";
 import DormModal from "./DormModal";
 import { getDormDetails } from "../_actions";
 import { Map, LayoutGrid } from "lucide-react";
@@ -149,16 +149,18 @@ export default function BrowseContent({
                     className={`flex flex-col cursor-pointer overflow-hidden rounded-xl bg-white shadow-sm transition-all hover:scale-[1.02] hover:shadow-md
                       ${selectedCardId === card.id ? "ring-2 ring-[#C9642A] ring-offset-2 scale-[1.01]" : ""}`}
                   >
-                    <Image
-                      src={
-                        card.image ||
-                        "/assets/placeholders/housing-414x264.svg"
-                      }
-                      alt={`${card.name} placeholder`}
-                      width={414}
-                      height={264}
-                      className="block h-auto w-full"
-                    />
+                    <div className="relative w-full" style={{ aspectRatio: '16/10' }}>
+                      <Image
+                        src={
+                          card.image ||
+                          "/assets/placeholders/housing-414x264.svg"
+                        }
+                        alt={card.name}
+                        fill
+                        sizes="(max-width: 768px) 100vw, 300px"
+                        className="object-cover"
+                      />
+                    </div>
                     <div className="flex-1 bg-[#1C2632] px-3.5 py-3 flex flex-col gap-1.5 font-[family-name:var(--font-geist-sans)]">
                       <div className="text-sm font-bold text-[#C9642A] truncate">
                         {card.name}

--- a/src/app/(main)/student/browse/_components/BrowseContent.tsx
+++ b/src/app/(main)/student/browse/_components/BrowseContent.tsx
@@ -294,52 +294,53 @@ export default function BrowseContent({
             overflow: hidden;
           }
 
-          .browse-map-panel {
+          .browse-root.map-visible .browse-map-panel {
             width: 50%;
-            height: 100%;
+            height: calc(100vh - 5.5rem);
+            min-height: 0;
             flex-shrink: 0;
           }
 
-          .browse-content-panel {
+          .browse-root.map-visible .browse-content-panel {
             width: 50%;
-            height: 100%;
+            height: calc(100vh - 5.5rem);
             display: flex;
             flex-direction: column;
             overflow: hidden;
           }
 
-          .browse-cards-scroll {
+          .browse-root.map-visible .browse-cards-scroll {
             flex: 1;
             overflow-y: auto;
             padding: 1rem 1.5rem 2rem;
           }
 
-          .browse-cards-grid {
+          .browse-root.map-visible .browse-cards-grid {
             grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
             gap: 0.75rem;
           }
 
-          .browse-cards-scroll::-webkit-scrollbar {
+          .browse-root.map-visible .browse-cards-scroll::-webkit-scrollbar {
             width: 6px;
           }
-          .browse-cards-scroll::-webkit-scrollbar-track {
+          .browse-root.map-visible .browse-cards-scroll::-webkit-scrollbar-track {
             background: transparent;
           }
-          .browse-cards-scroll::-webkit-scrollbar-thumb {
+          .browse-root.map-visible .browse-cards-scroll::-webkit-scrollbar-thumb {
             background: rgba(28, 38, 50, 0.15);
             border-radius: 3px;
           }
-          .browse-cards-scroll::-webkit-scrollbar-thumb:hover {
+          .browse-root.map-visible .browse-cards-scroll::-webkit-scrollbar-thumb:hover {
             background: rgba(28, 38, 50, 0.3);
           }
 
-          .browse-toolbar {
+          .browse-root.map-visible .browse-toolbar {
             padding: 0.5rem 1.5rem;
           }
         }
 
         @media (min-width: 1440px) {
-          .browse-map-panel {
+          .browse-root.map-visible .browse-map-panel {
             width: 55%;
           }
 
@@ -347,7 +348,7 @@ export default function BrowseContent({
             width: 45%;
           }
 
-          .browse-cards-grid {
+          .browse-root.map-visible .browse-cards-grid {
             grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
           }
         }
@@ -361,10 +362,15 @@ export default function BrowseContent({
           flex-direction: column;
         }
 
+        .browse-root.map-hidden .browse-content-panel {
+          width: 100%;
+        }
+
         .browse-root.map-hidden .browse-cards-scroll {
           max-width: 80rem;
           margin: 0 auto;
           width: 100%;
+          padding: 1rem 1.5rem 2rem;
         }
 
         .browse-root.map-hidden .browse-toolbar {

--- a/src/app/(main)/student/browse/_components/BrowseContent.tsx
+++ b/src/app/(main)/student/browse/_components/BrowseContent.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import { useState, useCallback, type ReactNode } from "react";
+import Image from "next/image";
+import HousingMap, { type HousingMarker } from "./HousingMap";
+import DormModal from "./DormModal";
+import { getDormDetails } from "../_actions";
+import { Map, LayoutGrid } from "lucide-react";
+
+/* ────────────────────── Types ────────────────────── */
+
+interface HousingCard {
+  id: number;
+  name: string;
+  type: string;
+  price: number | string;
+  image?: string | null;
+  lat: number | null;
+  lng: number | null;
+}
+
+interface BrowseContentProps {
+  cards: HousingCard[];
+  searchBar: ReactNode;
+  emptyState: ReactNode | null;
+}
+
+/* ────────────────────── Component ────────────────────── */
+
+export default function BrowseContent({
+  cards,
+  searchBar,
+  emptyState,
+}: BrowseContentProps) {
+  const [selectedDorm, setSelectedDorm] = useState<any>(null);
+  const [isFetching, setIsFetching] = useState(false);
+  const [showMap, setShowMap] = useState(true);
+  const [selectedCardId, setSelectedCardId] = useState<number | null>(null);
+
+  // Build map markers from real DB coordinates
+  const markers: HousingMarker[] = cards
+    .filter((card) => card.lat !== null && card.lng !== null)
+    .map((card) => ({
+      id: card.id,
+      name: card.name,
+      type: card.type,
+      price: card.price,
+      lat: card.lat!,
+      lng: card.lng!,
+      image: card.image,
+    }));
+
+  const handleCardClick = useCallback(async (id: number) => {
+    setSelectedCardId(id);
+    setIsFetching(true);
+    try {
+      const data = await getDormDetails(id);
+      if (data) {
+        setSelectedDorm({
+          id: data.housing_id,
+          name: data.housing_name,
+          address: data.housing_address,
+          housing_type: data.housing_type,
+          price: data.rent_price,
+          image: data.housing_image,
+          appli_start: data.start_application_date
+            ? new Date(data.start_application_date).toLocaleDateString(
+                "en-US",
+                { month: "long", day: "numeric", year: "numeric" }
+              )
+            : "TBA",
+          appli_end: data.end_application_date
+            ? new Date(data.end_application_date).toLocaleDateString("en-US", {
+                month: "long",
+                day: "numeric",
+                year: "numeric",
+              })
+            : "TBA",
+        });
+      }
+    } finally {
+      setIsFetching(false);
+    }
+  }, []);
+
+  const handleMarkerClick = useCallback(
+    (id: number) => {
+      setSelectedCardId(id);
+      handleCardClick(id);
+    },
+    [handleCardClick]
+  );
+
+  return (
+    <>
+      {/* Fetching overlay */}
+      {isFetching && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/20">
+          <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-[#C9642A]" />
+        </div>
+      )}
+
+      <div className={`browse-root ${showMap ? "map-visible" : "map-hidden"}`}>
+        {/* ── Left: Map ── */}
+        {showMap && (
+          <div className="browse-map-panel">
+            <HousingMap
+              housings={markers}
+              selectedId={selectedCardId}
+              onMarkerClick={handleMarkerClick}
+            />
+          </div>
+        )}
+
+        {/* ── Right: Search + Cards ── */}
+        <div className="browse-content-panel">
+          {/* Search bar + toggle */}
+          <div className="browse-toolbar">
+            <div className="browse-search-area">{searchBar}</div>
+            <button
+              onClick={() => setShowMap(!showMap)}
+              className="browse-toggle-btn"
+              id="toggle-map-view"
+            >
+              {showMap ? (
+                <>
+                  <LayoutGrid size={16} />
+                  <span className="hidden sm:inline">Cards Only</span>
+                </>
+              ) : (
+                <>
+                  <Map size={16} />
+                  <span className="hidden sm:inline">Show Map</span>
+                </>
+              )}
+            </button>
+          </div>
+
+          {/* Scrollable cards area */}
+          <div className="browse-cards-scroll">
+            {emptyState ? (
+              <div className="p-6">{emptyState}</div>
+            ) : (
+              <div className="browse-cards-grid">
+                {cards.map((card) => (
+                  <div
+                    key={card.id}
+                    onClick={() => handleCardClick(card.id)}
+                    className={`flex flex-col cursor-pointer overflow-hidden rounded-xl bg-white shadow-sm transition-all hover:scale-[1.02] hover:shadow-md
+                      ${selectedCardId === card.id ? "ring-2 ring-[#C9642A] ring-offset-2 scale-[1.01]" : ""}`}
+                  >
+                    <Image
+                      src={
+                        card.image ||
+                        "/assets/placeholders/housing-414x264.svg"
+                      }
+                      alt={`${card.name} placeholder`}
+                      width={414}
+                      height={264}
+                      className="block h-auto w-full"
+                    />
+                    <div className="flex-1 bg-[#1C2632] px-3.5 py-3 flex flex-col gap-1.5 font-[family-name:var(--font-geist-sans)]">
+                      <div className="text-sm font-bold text-[#C9642A] truncate">
+                        {card.name}
+                      </div>
+                      <div className="flex justify-between items-center text-[11px] text-white/60">
+                        <span className="bg-white/10 px-2 py-0.5 rounded-full">
+                          {card.type}
+                        </span>
+                        <span className="font-semibold text-white/90">
+                          ₱{card.price}/mo
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Modal */}
+      {selectedDorm && (
+        <DormModal dorm={selectedDorm} onClose={() => setSelectedDorm(null)} />
+      )}
+
+      <style>{`
+        /* ═══════════════════════════════════════
+           ROOT LAYOUT
+           ═══════════════════════════════════════ */
+
+        .browse-root {
+          width: 100%;
+          flex: 1;
+          background: #EDE9DE;
+        }
+
+        /* ═══════════════════════════════════════
+           MAP PANEL
+           ═══════════════════════════════════════ */
+
+        .browse-map-panel {
+          width: 100%;
+          height: 45vh;
+          position: relative;
+        }
+
+        /* ═══════════════════════════════════════
+           CONTENT PANEL (Search + Cards)
+           ═══════════════════════════════════════ */
+
+        .browse-content-panel {
+          display: flex;
+          flex-direction: column;
+          min-height: 0;
+        }
+
+        /* ─── Toolbar: search + toggle ─── */
+        .browse-toolbar {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+          padding: 0.5rem 1rem;
+          background: #EDE9DE;
+        }
+
+        .browse-search-area {
+          flex: 1;
+          min-width: 0;
+        }
+
+        .browse-search-area > div {
+          width: 100% !important;
+          margin: 0 !important;
+          padding: 0.5rem 0 !important;
+        }
+
+        .browse-toggle-btn {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 0.5rem;
+          padding: 0.5rem 1rem;
+          border-radius: 9999px;
+          border: none;
+          background: #1C2632;
+          color: white;
+          font-size: 0.8125rem;
+          font-weight: 600;
+          font-family: var(--font-geist-sans), sans-serif;
+          cursor: pointer;
+          white-space: nowrap;
+          transition: background 0.2s, transform 0.15s;
+          box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+          min-height: 2.5rem;
+          min-width: 2.5rem;
+          flex-shrink: 0;
+        }
+
+        .browse-toggle-btn:hover {
+          background: #2a3a4e;
+        }
+
+        .browse-toggle-btn:active {
+          transform: scale(0.95);
+        }
+
+        /* ─── Scrollable cards ─── */
+        .browse-cards-scroll {
+          flex: 1;
+          overflow-y: auto;
+          padding: 0.75rem 1rem 2rem;
+        }
+
+        .browse-cards-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+          gap: 0.75rem;
+        }
+
+        /* ═══════════════════════════════════════
+           DESKTOP: Full-bleed split layout
+           ═══════════════════════════════════════ */
+
+        @media (min-width: 1024px) {
+          .browse-root.map-visible {
+            display: grid;
+            grid-template-columns: 50% 50%;
+            height: calc(100vh - 5.5rem);
+            overflow: hidden;
+          }
+
+          .browse-map-panel {
+            height: 100%;
+            position: sticky;
+            top: 0;
+          }
+
+          .browse-content-panel {
+            height: 100%;
+            overflow: hidden;
+            display: flex;
+            flex-direction: column;
+          }
+
+          .browse-cards-scroll {
+            flex: 1;
+            overflow-y: auto;
+            padding: 1rem 1.5rem 2rem;
+          }
+
+          .browse-cards-grid {
+            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+            gap: 0.75rem;
+          }
+
+          .browse-cards-scroll::-webkit-scrollbar {
+            width: 6px;
+          }
+          .browse-cards-scroll::-webkit-scrollbar-track {
+            background: transparent;
+          }
+          .browse-cards-scroll::-webkit-scrollbar-thumb {
+            background: rgba(28, 38, 50, 0.15);
+            border-radius: 3px;
+          }
+          .browse-cards-scroll::-webkit-scrollbar-thumb:hover {
+            background: rgba(28, 38, 50, 0.3);
+          }
+
+          .browse-toolbar {
+            padding: 0.5rem 1.5rem;
+          }
+        }
+
+        @media (min-width: 1440px) {
+          .browse-root.map-visible {
+            grid-template-columns: 55% 45%;
+          }
+
+          .browse-cards-grid {
+            grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+          }
+        }
+
+        /* ═══════════════════════════════════════
+           CARDS-ONLY MODE
+           ═══════════════════════════════════════ */
+
+        .browse-root.map-hidden {
+          display: flex;
+          flex-direction: column;
+        }
+
+        .browse-root.map-hidden .browse-cards-scroll {
+          max-width: 80rem;
+          margin: 0 auto;
+          width: 100%;
+        }
+
+        .browse-root.map-hidden .browse-toolbar {
+          max-width: 80rem;
+          margin: 0 auto;
+          width: 100%;
+        }
+
+        .browse-root.map-hidden .browse-cards-grid {
+          grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+          gap: 1rem;
+        }
+      `}</style>
+    </>
+  );
+}

--- a/src/app/(main)/student/browse/_components/BrowseContent.tsx
+++ b/src/app/(main)/student/browse/_components/BrowseContent.tsx
@@ -283,32 +283,34 @@ export default function BrowseContent({
         }
 
         /* ═══════════════════════════════════════
-           DESKTOP: Flex split, map sticks on scroll
+           DESKTOP: Both panels locked to viewport
            ═══════════════════════════════════════ */
 
         @media (min-width: 1024px) {
           .browse-root.map-visible {
             display: flex;
             flex-direction: row;
-            align-items: flex-start;
+            height: calc(100vh - 5.5rem);
+            overflow: hidden;
           }
 
-          /* Map: sticks to viewport while cards scroll */
           .browse-map-panel {
             width: 50%;
-            height: calc(100vh - 5.5rem);
+            height: 100%;
             flex-shrink: 0;
-            overflow: hidden;
-            position: sticky;
-            top: 5.5rem;
           }
 
           .browse-content-panel {
             width: 50%;
-            min-height: calc(100vh - 5.5rem);
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
           }
 
           .browse-cards-scroll {
+            flex: 1;
+            overflow-y: auto;
             padding: 1rem 1.5rem 2rem;
           }
 

--- a/src/app/(main)/student/browse/_components/BrowseContent.tsx
+++ b/src/app/(main)/student/browse/_components/BrowseContent.tsx
@@ -283,35 +283,32 @@ export default function BrowseContent({
         }
 
         /* ═══════════════════════════════════════
-           DESKTOP: Flex split, map doesn't scroll
+           DESKTOP: Flex split, map sticks on scroll
            ═══════════════════════════════════════ */
 
         @media (min-width: 1024px) {
           .browse-root.map-visible {
             display: flex;
             flex-direction: row;
-            height: calc(100vh - 5.5rem);
-            overflow: hidden;
+            align-items: flex-start;
           }
 
+          /* Map: sticks to viewport while cards scroll */
           .browse-map-panel {
             width: 50%;
-            height: 100%;
+            height: calc(100vh - 5.5rem);
             flex-shrink: 0;
             overflow: hidden;
+            position: sticky;
+            top: 5.5rem;
           }
 
           .browse-content-panel {
             width: 50%;
-            height: 100%;
-            display: flex;
-            flex-direction: column;
-            overflow: hidden;
+            min-height: calc(100vh - 5.5rem);
           }
 
           .browse-cards-scroll {
-            flex: 1;
-            overflow-y: auto;
             padding: 1rem 1.5rem 2rem;
           }
 

--- a/src/app/(main)/student/browse/_components/HousingMap.tsx
+++ b/src/app/(main)/student/browse/_components/HousingMap.tsx
@@ -1,0 +1,508 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import maplibregl from "maplibre-gl";
+import "maplibre-gl/dist/maplibre-gl.css";
+import { MapPin, Layers, Navigation, X } from "lucide-react";
+
+/* ────────────────────── Types ────────────────────── */
+
+export interface HousingMarker {
+  id: number;
+  name: string;
+  type: string;
+  price: number | string;
+  lat: number;
+  lng: number;
+  image?: string | null;
+}
+
+interface HousingMapProps {
+  housings: HousingMarker[];
+  selectedId?: number | null;
+  onMarkerClick?: (id: number) => void;
+  onClose?: () => void;
+}
+
+/* ────────────────────── Constants ────────────────────── */
+
+// UPLB campus center (Los Baños, Laguna)
+const CAMPUS_CENTER: [number, number] = [121.24125948460573, 14.16323736946326];
+const DEFAULT_ZOOM = 15.5;
+const DEFAULT_PITCH = 50;
+const DEFAULT_BEARING = -30;
+
+const BUILDING_LAYER_ID = "building-3d";
+const HIGHLIGHT_SOURCE_ID = "casa-highlighted-buildings";
+const HIGHLIGHT_LAYER_ID = "casa-highlighted-buildings-3d";
+
+const BRAND_ORANGE = "#C9642A";
+const BRAND_DARK = "#1C2632";
+const BUILDING_HIGHLIGHT_COLOR = "#facc15";
+
+/* ────────────────────── Component ────────────────────── */
+
+export default function HousingMap({
+  housings,
+  selectedId,
+  onMarkerClick,
+  onClose,
+}: HousingMapProps) {
+  const mapContainerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
+  const markersRef = useRef<maplibregl.Marker[]>([]);
+  const rotationFrameRef = useRef<number | null>(null);
+  const [mapLoaded, setMapLoaded] = useState(false);
+  const [is3D, setIs3D] = useState(true);
+
+  /* ── Initialize map ── */
+  useEffect(() => {
+    if (!mapContainerRef.current || mapRef.current) return;
+
+    const map = new maplibregl.Map({
+      container: mapContainerRef.current,
+      style: "/map-style.json",
+      center: CAMPUS_CENTER,
+      zoom: DEFAULT_ZOOM,
+      pitch: DEFAULT_PITCH,
+      bearing: DEFAULT_BEARING,
+      minZoom: 13,
+      maxBounds: [
+        [121.20, 14.13],
+        [121.29, 14.19],
+      ],
+    });
+
+    map.addControl(
+      new maplibregl.NavigationControl({ visualizePitch: true }),
+      "bottom-right"
+    );
+
+    map.on("load", () => {
+      // Add 3D building extrusions
+      if (!map.getLayer(BUILDING_LAYER_ID)) {
+        const layers = map.getStyle().layers;
+        // Find the label layer to insert buildings below it
+        let labelLayerId: string | undefined;
+        for (const layer of layers || []) {
+          if (
+            layer.type === "symbol" &&
+            (layer as any).layout?.["text-field"]
+          ) {
+            labelLayerId = layer.id;
+            break;
+          }
+        }
+
+        map.addLayer(
+          {
+            id: BUILDING_LAYER_ID,
+            source: "openmaptiles",
+            "source-layer": "building",
+            type: "fill-extrusion",
+            minzoom: 14,
+            paint: {
+              "fill-extrusion-color": "rgba(247, 242, 235, 1)",
+              "fill-extrusion-height": ["get", "render_height"],
+              "fill-extrusion-base": ["get", "render_min_height"],
+              "fill-extrusion-opacity": 0.85,
+            },
+          },
+          labelLayerId
+        );
+      }
+
+      setMapLoaded(true);
+    });
+
+    // Stop rotation on user interaction
+    const stopRotation = () => {
+      if (rotationFrameRef.current !== null) {
+        cancelAnimationFrame(rotationFrameRef.current);
+        rotationFrameRef.current = null;
+      }
+    };
+
+    map.on("mousedown", stopRotation);
+    map.on("touchstart", stopRotation);
+    map.on("wheel", stopRotation);
+
+    mapRef.current = map;
+
+    return () => {
+      stopRotation();
+      map.remove();
+      mapRef.current = null;
+    };
+  }, []);
+
+  /* ── Create markers (only when data or map changes, NOT on selection) ── */
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !mapLoaded) return;
+
+    // Clear existing markers
+    markersRef.current.forEach((m) => m.remove());
+    markersRef.current = [];
+
+    for (const housing of housings) {
+      if (!housing.lat || !housing.lng) continue;
+
+      const el = document.createElement("div");
+      el.className = "casa-map-marker";
+      el.dataset.housingId = String(housing.id);
+
+      el.innerHTML = `
+        <div class="marker-pin">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+            <polyline points="9 22 9 12 15 12 15 22"/>
+          </svg>
+        </div>
+        <div class="marker-label">${housing.name}</div>
+      `;
+
+      el.addEventListener("click", (e) => {
+        e.stopPropagation();
+        onMarkerClick?.(housing.id);
+      });
+
+      const marker = new maplibregl.Marker({ element: el, anchor: "center" })
+        .setLngLat([housing.lng, housing.lat])
+        .addTo(map);
+
+      markersRef.current.push(marker);
+    }
+  }, [housings, mapLoaded, onMarkerClick]);
+
+  /* ── Toggle active class on selection (no marker recreation) ── */
+  useEffect(() => {
+    document.querySelectorAll(".casa-map-marker").forEach((el) => {
+      const id = (el as HTMLElement).dataset.housingId;
+      el.classList.toggle("active", id === String(selectedId));
+    });
+  }, [selectedId]);
+
+  /* ── Fly to selected housing ── */
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !mapLoaded || !selectedId) return;
+
+    const housing = housings.find((h) => h.id === selectedId);
+    if (!housing || !housing.lat || !housing.lng) return;
+
+    // Stop any existing rotation
+    if (rotationFrameRef.current !== null) {
+      cancelAnimationFrame(rotationFrameRef.current);
+      rotationFrameRef.current = null;
+    }
+
+    map.flyTo({
+      center: [housing.lng, housing.lat],
+      zoom: 17.5,
+      pitch: 60,
+      duration: 1500,
+      essential: true,
+    });
+
+    // Start gentle rotation after fly-to completes
+    map.once("moveend", () => {
+      if (!mapRef.current) return;
+      let bearing = map.getBearing();
+      let lastTs = 0;
+
+      const rotate = (ts: number) => {
+        if (!mapRef.current) return;
+        if (!lastTs) lastTs = ts;
+        const delta = ts - lastTs;
+        lastTs = ts;
+        bearing = (bearing + delta / 150) % 360;
+        map.rotateTo(bearing, { duration: 0 });
+        rotationFrameRef.current = requestAnimationFrame(rotate);
+      };
+
+      rotationFrameRef.current = requestAnimationFrame(rotate);
+    });
+
+
+  }, [selectedId, mapLoaded, housings]);
+
+  /* ── Toggle 3D ── */
+  const toggle3D = useCallback(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    if (is3D) {
+      map.easeTo({ pitch: 0, bearing: 0, duration: 800 });
+      if (map.getLayer(BUILDING_LAYER_ID)) {
+        map.setPaintProperty(BUILDING_LAYER_ID, "fill-extrusion-opacity", 0);
+      }
+    } else {
+      map.easeTo({ pitch: DEFAULT_PITCH, duration: 800 });
+      if (map.getLayer(BUILDING_LAYER_ID)) {
+        map.setPaintProperty(
+          BUILDING_LAYER_ID,
+          "fill-extrusion-opacity",
+          0.85
+        );
+      }
+    }
+    setIs3D(!is3D);
+  }, [is3D]);
+
+  /* ── Reset view ── */
+  const resetView = useCallback(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    if (rotationFrameRef.current !== null) {
+      cancelAnimationFrame(rotationFrameRef.current);
+      rotationFrameRef.current = null;
+    }
+
+    map.flyTo({
+      center: CAMPUS_CENTER,
+      zoom: DEFAULT_ZOOM,
+      pitch: DEFAULT_PITCH,
+      bearing: DEFAULT_BEARING,
+      duration: 1500,
+    });
+  }, []);
+
+  return (
+    <div className="housing-map-wrapper">
+      {/* Loading overlay */}
+      {!mapLoaded && (
+        <div className="map-loading">
+          <div className="map-loading-spinner" />
+          <span>Loading map…</span>
+        </div>
+      )}
+
+      {/* Map container */}
+      <div ref={mapContainerRef} className="map-container" />
+
+      {/* Controls */}
+      <div className="map-controls">
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="map-control-btn map-close-btn"
+            title="Close map"
+          >
+            <X size={18} />
+          </button>
+        )}
+        <button
+          onClick={toggle3D}
+          className={`map-control-btn ${is3D ? "active" : ""}`}
+          title={is3D ? "Switch to 2D" : "Switch to 3D"}
+        >
+          <Layers size={18} />
+        </button>
+        <button
+          onClick={resetView}
+          className="map-control-btn"
+          title="Reset view"
+        >
+          <Navigation size={18} />
+        </button>
+      </div>
+
+      <style>{`
+        .housing-map-wrapper {
+          position: relative;
+          width: 100%;
+          height: 100%;
+          overflow: hidden;
+          background: #1C2632;
+        }
+
+        .map-container {
+          width: 100%;
+          height: 100%;
+        }
+
+        /* Loading */
+        .map-loading {
+          position: absolute;
+          inset: 0;
+          z-index: 10;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          gap: 0.75rem;
+          background: #1C2632;
+          color: rgba(255,255,255,0.7);
+          font-size: 0.875rem;
+          font-family: var(--font-geist-sans), sans-serif;
+        }
+
+        .map-loading-spinner {
+          width: 2rem;
+          height: 2rem;
+          border: 3px solid rgba(255,255,255,0.15);
+          border-top-color: #C9642A;
+          border-radius: 50%;
+          animation: map-spin 0.8s linear infinite;
+        }
+
+        @keyframes map-spin {
+          to { transform: rotate(360deg); }
+        }
+
+        /* Controls */
+        .map-controls {
+          position: absolute;
+          top: 0.75rem;
+          left: 0.75rem;
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+          z-index: 5;
+        }
+
+        .map-control-btn {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 2.25rem;
+          height: 2.25rem;
+          min-height: 2.25rem;
+          min-width: 2.25rem;
+          border-radius: 0.5rem;
+          border: none;
+          background: rgba(28, 38, 50, 0.85);
+          color: rgba(255,255,255,0.8);
+          cursor: pointer;
+          backdrop-filter: blur(8px);
+          transition: all 0.2s;
+          box-shadow: 0 2px 8px rgba(0,0,0,0.25);
+        }
+
+        .map-control-btn:hover {
+          background: rgba(28, 38, 50, 0.95);
+          color: #C9642A;
+          transform: scale(1.05);
+        }
+
+        .map-control-btn.active {
+          background: #C9642A;
+          color: white;
+        }
+
+        .map-close-btn {
+          background: rgba(180, 40, 40, 0.85);
+          color: white;
+        }
+
+        .map-close-btn:hover {
+          background: rgba(200, 50, 50, 0.95);
+          color: white;
+        }
+
+        /* Markers */
+        .casa-map-marker {
+          cursor: pointer;
+          position: relative;
+          z-index: 1;
+          width: 2.25rem;
+          height: 2.25rem;
+        }
+
+        .casa-map-marker.active {
+          z-index: 60;
+        }
+
+        .marker-pin {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 2.25rem;
+          height: 2.25rem;
+          border-radius: 50%;
+          background: ${BRAND_ORANGE};
+          border: 2.5px solid white;
+          color: white;
+          box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+          transition: transform 0.2s, background-color 0.2s;
+        }
+
+        .casa-map-marker:hover .marker-pin,
+        .casa-map-marker.active .marker-pin {
+          transform: scale(1.2);
+          background: #a8511e;
+        }
+
+        .casa-map-marker.active .marker-pin {
+          background: ${BRAND_DARK};
+          outline: 2.5px solid ${BRAND_ORANGE};
+          outline-offset: 2px;
+        }
+
+        .marker-label {
+          position: absolute;
+          bottom: calc(100% + 0.4rem);
+          left: 50%;
+          transform: translateX(-50%);
+          background: white;
+          color: ${BRAND_DARK};
+          border-radius: 0.5rem;
+          padding: 0.25rem 0.625rem;
+          font-size: 0.7rem;
+          font-weight: 600;
+          font-family: var(--font-geist-sans), sans-serif;
+          white-space: nowrap;
+          box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+          opacity: 0;
+          pointer-events: none;
+          transition: opacity 0.2s;
+        }
+
+        .casa-map-marker:hover .marker-label,
+        .casa-map-marker.active .marker-label {
+          opacity: 1;
+        }
+
+        /* Override MapLibre defaults for CASA branding */
+        .housing-map-wrapper .maplibregl-ctrl-group {
+          background: rgba(28, 38, 50, 0.85) !important;
+          border: none !important;
+          border-radius: 0.5rem !important;
+          overflow: hidden;
+          backdrop-filter: blur(8px);
+          box-shadow: 0 2px 8px rgba(0,0,0,0.25) !important;
+        }
+
+        .housing-map-wrapper .maplibregl-ctrl-group button {
+          width: 2.25rem !important;
+          height: 2.25rem !important;
+          min-height: 2.25rem !important;
+          min-width: 2.25rem !important;
+          border: none !important;
+          background: transparent !important;
+        }
+
+        .housing-map-wrapper .maplibregl-ctrl-group button + button {
+          border-top: 1px solid rgba(255,255,255,0.1) !important;
+        }
+
+        .housing-map-wrapper .maplibregl-ctrl-group button .maplibregl-ctrl-icon {
+          filter: invert(1) brightness(0.85);
+        }
+
+        .housing-map-wrapper .maplibregl-ctrl-group button:hover .maplibregl-ctrl-icon {
+          filter: invert(1) brightness(1);
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .marker-pin,
+          .map-control-btn {
+            transition: none !important;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/app/(main)/student/browse/page.tsx
+++ b/src/app/(main)/student/browse/page.tsx
@@ -1,7 +1,6 @@
-import Image from "next/image";
 import SearchBar from "./_components/SearchBar";
 import StudentNavBar from "@/app/(main)/student/_components/StudentNavBar";
-import HousingCards from "./_components/HousingCards";
+import BrowseContent from "./_components/BrowseContent";
 import { userData } from "@/app/lib/data/user-data";
 import { getAllAvailableDorms } from "@/app/lib/data/student-browse";
 import type { Metadata } from "next";
@@ -9,7 +8,8 @@ import StateMessage from "@/app/components/ui/state-message";
 
 export const metadata: Metadata = {
   title: "Browse Housing",
-  description: "Explore available dormitories and housing options.",
+  description:
+    "Explore available dormitories and housing options near UPLB campus.",
 };
 
 export default async function DormBrowsePage({
@@ -56,13 +56,14 @@ export default async function DormBrowsePage({
     );
   }
 
-  //get housing names to put on cards
   const cards = allHousing.map((item) => ({
     id: item.housing_id,
     name: item.housing_name,
     type: item.housing_type,
     price: item.rent_price,
     image: item.housing_image,
+    lat: item.latitude ?? null,
+    lng: item.longitude ?? null,
   }));
 
   return (
@@ -72,19 +73,18 @@ export default async function DormBrowsePage({
         userId={currUser?.account_number}
       />
 
-      <SearchBar />
-
-      {/* HOUSING CARDS CONTAINER */}
-      <div className="w-full max-w-7xl mx-auto mt-4 md:mt-8 flex-1 bg-[#EDE9DE] p-6 md:p-10 rounded-t-[20px] font-[family-name:var(--font-geist-sans)] shadow-inner">
-        {cards.length === 0 ? (
-          <StateMessage
-            title="No housing results"
-            description="Try changing your filters or search query."
-          />
-        ) : (
-          <HousingCards cards={cards} />
-        )}
-      </div>
+      <BrowseContent
+        cards={cards}
+        searchBar={<SearchBar />}
+        emptyState={
+          cards.length === 0 ? (
+            <StateMessage
+              title="No housing results"
+              description="Try changing your filters or search query."
+            />
+          ) : null
+        }
+      />
     </div>
   );
 }

--- a/src/app/components/map/HousingMap.tsx
+++ b/src/app/components/map/HousingMap.tsx
@@ -148,10 +148,10 @@ export default function HousingMap({
     for (const housing of housings) {
       if (!housing.lat || !housing.lng) continue;
 
+      // Minimal marker element — just the pin circle, nothing else
       const el = document.createElement("div");
       el.className = "casa-map-marker";
       el.dataset.housingId = String(housing.id);
-
       el.innerHTML = `
         <div class="marker-pin">
           <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
@@ -159,15 +159,34 @@ export default function HousingMap({
             <polyline points="9 22 9 12 15 12 15 22"/>
           </svg>
         </div>
-        <div class="marker-label">${housing.name}</div>
       `;
+
+      // Tooltip popup for the label (not part of marker element)
+      const popup = new maplibregl.Popup({
+        closeButton: false,
+        closeOnClick: false,
+        offset: 20,
+        className: "casa-marker-popup",
+      }).setHTML(`<span>${housing.name}</span>`);
+
+      el.addEventListener("mouseenter", () => {
+        popup.setLngLat([housing.lng, housing.lat]).addTo(map);
+      });
+      el.addEventListener("mouseleave", () => {
+        popup.remove();
+      });
 
       el.addEventListener("click", (e) => {
         e.stopPropagation();
         onMarkerClick?.(housing.id);
       });
 
-      const marker = new maplibregl.Marker({ element: el, anchor: "center" })
+      const marker = new maplibregl.Marker({
+        element: el,
+        anchor: "center",
+        pitchAlignment: "viewport",
+        rotateAlignment: "viewport",
+      })
         .setLngLat([housing.lng, housing.lat])
         .addTo(map);
 
@@ -402,13 +421,11 @@ export default function HousingMap({
           color: white;
         }
 
-        /* Markers — stable positioning via intrinsic sizing (same as room-tba) */
+        /* Markers — minimal element for stable positioning */
         .casa-map-marker {
           line-height: 0;
           cursor: pointer;
-          position: relative;
           z-index: 1;
-          overflow: visible;
         }
 
         .casa-map-marker.active {
@@ -435,44 +452,25 @@ export default function HousingMap({
 
         .casa-map-marker.active .marker-pin {
           background: ${BRAND_DARK};
-        }
-
-        .casa-map-marker.active .marker-pin::before {
-          content: "";
-          position: absolute;
-          top: 0;
-          left: 0;
-          width: 100%;
-          height: 100%;
-          border-radius: 50%;
           outline: 2.5px solid ${BRAND_ORANGE};
           outline-offset: 2px;
         }
 
-        .marker-label {
-          line-height: normal;
-          position: absolute;
-          bottom: calc(100% + 0.5rem);
-          left: 50%;
-          translate: -50% 0;
+        /* Popup tooltip for marker hover */
+        .casa-marker-popup .maplibregl-popup-content {
           background: white;
           color: ${BRAND_DARK};
           border-radius: 0.5rem;
           padding: 0.25rem 0.625rem;
-          font-size: 0.7rem;
+          font-size: 0.75rem;
           font-weight: 600;
           font-family: var(--font-geist-sans), sans-serif;
           white-space: nowrap;
-          width: max-content;
           box-shadow: 0 2px 8px rgba(0,0,0,0.15);
-          opacity: 0;
-          pointer-events: none;
-          transition: opacity 0.2s;
         }
 
-        .casa-map-marker:hover .marker-label,
-        .casa-map-marker.active .marker-label {
-          opacity: 1;
+        .casa-marker-popup .maplibregl-popup-tip {
+          border-top-color: white;
         }
 
         /* Override MapLibre defaults for CASA branding */

--- a/src/app/components/map/HousingMap.tsx
+++ b/src/app/components/map/HousingMap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, useMemo } from "react";
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { Layers, Navigation, X } from "lucide-react";
@@ -54,8 +54,8 @@ export default function HousingMap({
   const [mapLoaded, setMapLoaded] = useState(false);
   const [is3D, setIs3D] = useState(true);
 
-  /* ── Build GeoJSON from housing data ── */
-  const geojson: GeoJSON.FeatureCollection = {
+  /* ── Build GeoJSON from housing data (memoized to avoid infinite loops) ── */
+  const geojson = useMemo<GeoJSON.FeatureCollection>(() => ({
     type: "FeatureCollection",
     features: housings
       .filter((h) => h.lat && h.lng)
@@ -73,7 +73,7 @@ export default function HousingMap({
           selected: h.id === selectedId ? 1 : 0,
         },
       })),
-  };
+  }), [housings, selectedId]);
 
   /* ── Initialize map ── */
   useEffect(() => {
@@ -99,6 +99,9 @@ export default function HousingMap({
     );
 
     map.on("load", () => {
+      // Force resize so canvas matches container
+      map.resize();
+
       // 3D building extrusions
       if (!map.getLayer(BUILDING_LAYER_ID)) {
         const layers = map.getStyle().layers;
@@ -222,6 +225,12 @@ export default function HousingMap({
       setMapLoaded(true);
     });
 
+    // Auto-resize when container dimensions change
+    const ro = new ResizeObserver(() => {
+      map.resize();
+    });
+    ro.observe(mapContainerRef.current);
+
     // Stop rotation on interaction
     const stopRotation = () => {
       if (rotationFrameRef.current !== null) {
@@ -237,6 +246,7 @@ export default function HousingMap({
 
     return () => {
       stopRotation();
+      ro.disconnect();
       map.remove();
       mapRef.current = null;
     };

--- a/src/app/components/map/HousingMap.tsx
+++ b/src/app/components/map/HousingMap.tsx
@@ -134,59 +134,105 @@ export default function HousingMap({
         );
       }
 
-      // Housing markers — GeoJSON source + circle layer (rendered in WebGL)
+      // Create house icon via canvas for crisp rendering
+      const size = 48;
+      const canvas = document.createElement("canvas");
+      canvas.width = size;
+      canvas.height = size;
+      const ctx = canvas.getContext("2d")!;
+
+      // White circle background with border
+      ctx.beginPath();
+      ctx.arc(size / 2, size / 2, size / 2 - 2, 0, Math.PI * 2);
+      ctx.fillStyle = BRAND_ORANGE;
+      ctx.fill();
+      ctx.strokeStyle = "#ffffff";
+      ctx.lineWidth = 3;
+      ctx.stroke();
+
+      // House icon (simplified path)
+      const cx = size / 2;
+      const cy = size / 2;
+      const s = 10; // icon scale
+
+      ctx.fillStyle = "#ffffff";
+      ctx.strokeStyle = "#ffffff";
+      ctx.lineWidth = 1.5;
+      ctx.lineCap = "round";
+      ctx.lineJoin = "round";
+
+      // Roof
+      ctx.beginPath();
+      ctx.moveTo(cx - s, cy);
+      ctx.lineTo(cx, cy - s);
+      ctx.lineTo(cx + s, cy);
+      ctx.closePath();
+      ctx.fill();
+
+      // House body
+      ctx.fillRect(cx - s * 0.7, cy - 1, s * 1.4, s * 0.9);
+
+      // Door
+      ctx.fillStyle = BRAND_ORANGE;
+      ctx.fillRect(cx - s * 0.2, cy + s * 0.2, s * 0.4, s * 0.7);
+
+      const imageData = ctx.getImageData(0, 0, size, size);
+      map.addImage("casa-house-icon", imageData, { pixelRatio: 2 });
+
+      // Also create selected variant
+      const canvas2 = document.createElement("canvas");
+      canvas2.width = size;
+      canvas2.height = size;
+      const ctx2 = canvas2.getContext("2d")!;
+
+      ctx2.beginPath();
+      ctx2.arc(size / 2, size / 2, size / 2 - 2, 0, Math.PI * 2);
+      ctx2.fillStyle = BRAND_DARK;
+      ctx2.fill();
+      ctx2.strokeStyle = BRAND_ORANGE;
+      ctx2.lineWidth = 3;
+      ctx2.stroke();
+
+      ctx2.fillStyle = "#ffffff";
+      ctx2.beginPath();
+      ctx2.moveTo(cx - s, cy);
+      ctx2.lineTo(cx, cy - s);
+      ctx2.lineTo(cx + s, cy);
+      ctx2.closePath();
+      ctx2.fill();
+      ctx2.fillRect(cx - s * 0.7, cy - 1, s * 1.4, s * 0.9);
+      ctx2.fillStyle = BRAND_DARK;
+      ctx2.fillRect(cx - s * 0.2, cy + s * 0.2, s * 0.4, s * 0.7);
+
+      const imageData2 = ctx2.getImageData(0, 0, size, size);
+      map.addImage("casa-house-icon-selected", imageData2, { pixelRatio: 2 });
+
+      // Housing markers — GeoJSON source + symbol layer
       map.addSource(MARKERS_SOURCE_ID, {
         type: "geojson",
         data: { type: "FeatureCollection", features: [] },
       });
 
-      // Outer white ring
-      map.addLayer({
-        id: MARKERS_CIRCLE_LAYER + "-ring",
-        source: MARKERS_SOURCE_ID,
-        type: "circle",
-        paint: {
-          "circle-radius": ["case", ["==", ["get", "selected"], 1], 14, 12],
-          "circle-color": "#ffffff",
-          "circle-stroke-width": 0,
-        },
-      });
-
-      // Inner colored circle
-      map.addLayer({
-        id: MARKERS_CIRCLE_LAYER,
-        source: MARKERS_SOURCE_ID,
-        type: "circle",
-        paint: {
-          "circle-radius": ["case", ["==", ["get", "selected"], 1], 11, 9],
-          "circle-color": [
-            "case",
-            ["==", ["get", "selected"], 1],
-            BRAND_DARK,
-            BRAND_ORANGE,
-          ],
-          "circle-stroke-width": 0,
-        },
-      });
-
-      // House icon as text label (using unicode)
+      // Single symbol layer with data-driven icon
       map.addLayer({
         id: MARKERS_ICON_LAYER,
         source: MARKERS_SOURCE_ID,
         type: "symbol",
         layout: {
-          "text-field": "⌂",
-          "text-size": ["case", ["==", ["get", "selected"], 1], 18, 14],
-          "text-allow-overlap": true,
-          "text-ignore-placement": true,
-        },
-        paint: {
-          "text-color": "#ffffff",
+          "icon-image": [
+            "case",
+            ["==", ["get", "selected"], 1],
+            "casa-house-icon-selected",
+            "casa-house-icon",
+          ],
+          "icon-size": ["case", ["==", ["get", "selected"], 1], 1.2, 0.9],
+          "icon-allow-overlap": true,
+          "icon-ignore-placement": true,
         },
       });
 
       // Click handler
-      map.on("click", MARKERS_CIRCLE_LAYER, (e) => {
+      map.on("click", MARKERS_ICON_LAYER, (e) => {
         const feature = e.features?.[0];
         if (feature?.properties?.id) {
           onMarkerClick?.(feature.properties.id);
@@ -194,7 +240,7 @@ export default function HousingMap({
       });
 
       // Hover cursor + popup
-      map.on("mouseenter", MARKERS_CIRCLE_LAYER, (e) => {
+      map.on("mouseenter", MARKERS_ICON_LAYER, (e) => {
         map.getCanvas().style.cursor = "pointer";
         const feature = e.features?.[0];
         if (feature && feature.geometry.type === "Point") {
@@ -214,7 +260,7 @@ export default function HousingMap({
         }
       });
 
-      map.on("mouseleave", MARKERS_CIRCLE_LAYER, () => {
+      map.on("mouseleave", MARKERS_ICON_LAYER, () => {
         map.getCanvas().style.cursor = "";
         if (popupRef.current) {
           popupRef.current.remove();

--- a/src/app/components/map/HousingMap.tsx
+++ b/src/app/components/map/HousingMap.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
-import { MapPin, Layers, Navigation, X } from "lucide-react";
+import { Layers, Navigation, X } from "lucide-react";
 
 /* ────────────────────── Types ────────────────────── */
 
@@ -26,19 +26,18 @@ interface HousingMapProps {
 
 /* ────────────────────── Constants ────────────────────── */
 
-// UPLB campus center (Los Baños, Laguna)
 const CAMPUS_CENTER: [number, number] = [121.24125948460573, 14.16323736946326];
 const DEFAULT_ZOOM = 15.5;
 const DEFAULT_PITCH = 50;
 const DEFAULT_BEARING = -30;
 
 const BUILDING_LAYER_ID = "building-3d";
-const HIGHLIGHT_SOURCE_ID = "casa-highlighted-buildings";
-const HIGHLIGHT_LAYER_ID = "casa-highlighted-buildings-3d";
+const MARKERS_SOURCE_ID = "casa-housing-markers";
+const MARKERS_CIRCLE_LAYER = "casa-markers-circle";
+const MARKERS_ICON_LAYER = "casa-markers-icon";
 
 const BRAND_ORANGE = "#C9642A";
 const BRAND_DARK = "#1C2632";
-const BUILDING_HIGHLIGHT_COLOR = "#facc15";
 
 /* ────────────────────── Component ────────────────────── */
 
@@ -50,10 +49,31 @@ export default function HousingMap({
 }: HousingMapProps) {
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
-  const markersRef = useRef<maplibregl.Marker[]>([]);
+  const popupRef = useRef<maplibregl.Popup | null>(null);
   const rotationFrameRef = useRef<number | null>(null);
   const [mapLoaded, setMapLoaded] = useState(false);
   const [is3D, setIs3D] = useState(true);
+
+  /* ── Build GeoJSON from housing data ── */
+  const geojson: GeoJSON.FeatureCollection = {
+    type: "FeatureCollection",
+    features: housings
+      .filter((h) => h.lat && h.lng)
+      .map((h) => ({
+        type: "Feature" as const,
+        geometry: {
+          type: "Point" as const,
+          coordinates: [h.lng, h.lat],
+        },
+        properties: {
+          id: h.id,
+          name: h.name,
+          type: h.type,
+          price: h.price,
+          selected: h.id === selectedId ? 1 : 0,
+        },
+      })),
+  };
 
   /* ── Initialize map ── */
   useEffect(() => {
@@ -79,10 +99,9 @@ export default function HousingMap({
     );
 
     map.on("load", () => {
-      // Add 3D building extrusions
+      // 3D building extrusions
       if (!map.getLayer(BUILDING_LAYER_ID)) {
         const layers = map.getStyle().layers;
-        // Find the label layer to insert buildings below it
         let labelLayerId: string | undefined;
         for (const layer of layers || []) {
           if (
@@ -112,17 +131,104 @@ export default function HousingMap({
         );
       }
 
+      // Housing markers — GeoJSON source + circle layer (rendered in WebGL)
+      map.addSource(MARKERS_SOURCE_ID, {
+        type: "geojson",
+        data: { type: "FeatureCollection", features: [] },
+      });
+
+      // Outer white ring
+      map.addLayer({
+        id: MARKERS_CIRCLE_LAYER + "-ring",
+        source: MARKERS_SOURCE_ID,
+        type: "circle",
+        paint: {
+          "circle-radius": ["case", ["==", ["get", "selected"], 1], 14, 12],
+          "circle-color": "#ffffff",
+          "circle-stroke-width": 0,
+        },
+      });
+
+      // Inner colored circle
+      map.addLayer({
+        id: MARKERS_CIRCLE_LAYER,
+        source: MARKERS_SOURCE_ID,
+        type: "circle",
+        paint: {
+          "circle-radius": ["case", ["==", ["get", "selected"], 1], 11, 9],
+          "circle-color": [
+            "case",
+            ["==", ["get", "selected"], 1],
+            BRAND_DARK,
+            BRAND_ORANGE,
+          ],
+          "circle-stroke-width": 0,
+        },
+      });
+
+      // House icon as text label (using unicode)
+      map.addLayer({
+        id: MARKERS_ICON_LAYER,
+        source: MARKERS_SOURCE_ID,
+        type: "symbol",
+        layout: {
+          "text-field": "⌂",
+          "text-size": ["case", ["==", ["get", "selected"], 1], 18, 14],
+          "text-allow-overlap": true,
+          "text-ignore-placement": true,
+        },
+        paint: {
+          "text-color": "#ffffff",
+        },
+      });
+
+      // Click handler
+      map.on("click", MARKERS_CIRCLE_LAYER, (e) => {
+        const feature = e.features?.[0];
+        if (feature?.properties?.id) {
+          onMarkerClick?.(feature.properties.id);
+        }
+      });
+
+      // Hover cursor + popup
+      map.on("mouseenter", MARKERS_CIRCLE_LAYER, (e) => {
+        map.getCanvas().style.cursor = "pointer";
+        const feature = e.features?.[0];
+        if (feature && feature.geometry.type === "Point") {
+          const coords = feature.geometry.coordinates as [number, number];
+          const name = feature.properties?.name ?? "";
+
+          if (popupRef.current) popupRef.current.remove();
+          popupRef.current = new maplibregl.Popup({
+            closeButton: false,
+            closeOnClick: false,
+            offset: 16,
+            className: "casa-marker-popup",
+          })
+            .setLngLat(coords)
+            .setHTML(`<span>${name}</span>`)
+            .addTo(map);
+        }
+      });
+
+      map.on("mouseleave", MARKERS_CIRCLE_LAYER, () => {
+        map.getCanvas().style.cursor = "";
+        if (popupRef.current) {
+          popupRef.current.remove();
+          popupRef.current = null;
+        }
+      });
+
       setMapLoaded(true);
     });
 
-    // Stop rotation on user interaction
+    // Stop rotation on interaction
     const stopRotation = () => {
       if (rotationFrameRef.current !== null) {
         cancelAnimationFrame(rotationFrameRef.current);
         rotationFrameRef.current = null;
       }
     };
-
     map.on("mousedown", stopRotation);
     map.on("touchstart", stopRotation);
     map.on("wheel", stopRotation);
@@ -134,73 +240,19 @@ export default function HousingMap({
       map.remove();
       mapRef.current = null;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  /* ── Create markers (only when data or map changes, NOT on selection) ── */
+  /* ── Update GeoJSON source when data or selection changes ── */
   useEffect(() => {
     const map = mapRef.current;
     if (!map || !mapLoaded) return;
 
-    // Clear existing markers
-    markersRef.current.forEach((m) => m.remove());
-    markersRef.current = [];
-
-    for (const housing of housings) {
-      if (!housing.lat || !housing.lng) continue;
-
-      // Minimal marker element — just the pin circle, nothing else
-      const el = document.createElement("div");
-      el.className = "casa-map-marker";
-      el.dataset.housingId = String(housing.id);
-      el.innerHTML = `
-        <div class="marker-pin">
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-            <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
-            <polyline points="9 22 9 12 15 12 15 22"/>
-          </svg>
-        </div>
-      `;
-
-      // Tooltip popup for the label (not part of marker element)
-      const popup = new maplibregl.Popup({
-        closeButton: false,
-        closeOnClick: false,
-        offset: 20,
-        className: "casa-marker-popup",
-      }).setHTML(`<span>${housing.name}</span>`);
-
-      el.addEventListener("mouseenter", () => {
-        popup.setLngLat([housing.lng, housing.lat]).addTo(map);
-      });
-      el.addEventListener("mouseleave", () => {
-        popup.remove();
-      });
-
-      el.addEventListener("click", (e) => {
-        e.stopPropagation();
-        onMarkerClick?.(housing.id);
-      });
-
-      const marker = new maplibregl.Marker({
-        element: el,
-        anchor: "center",
-        pitchAlignment: "viewport",
-        rotateAlignment: "viewport",
-      })
-        .setLngLat([housing.lng, housing.lat])
-        .addTo(map);
-
-      markersRef.current.push(marker);
+    const source = map.getSource(MARKERS_SOURCE_ID) as maplibregl.GeoJSONSource;
+    if (source) {
+      source.setData(geojson);
     }
-  }, [housings, mapLoaded, onMarkerClick]);
-
-  /* ── Toggle active class on selection (no marker recreation) ── */
-  useEffect(() => {
-    document.querySelectorAll(".casa-map-marker").forEach((el) => {
-      const id = (el as HTMLElement).dataset.housingId;
-      el.classList.toggle("active", id === String(selectedId));
-    });
-  }, [selectedId]);
+  }, [geojson, mapLoaded]);
 
   /* ── Fly to selected housing ── */
   useEffect(() => {
@@ -208,9 +260,8 @@ export default function HousingMap({
     if (!map || !mapLoaded || !selectedId) return;
 
     const housing = housings.find((h) => h.id === selectedId);
-    if (!housing || !housing.lat || !housing.lng) return;
+    if (!housing?.lat || !housing?.lng) return;
 
-    // Stop any existing rotation
     if (rotationFrameRef.current !== null) {
       cancelAnimationFrame(rotationFrameRef.current);
       rotationFrameRef.current = null;
@@ -224,7 +275,7 @@ export default function HousingMap({
       essential: true,
     });
 
-    // Start gentle rotation after fly-to completes
+    // Gentle rotation after fly-to
     map.once("moveend", () => {
       if (!mapRef.current) return;
       let bearing = map.getBearing();
@@ -242,8 +293,6 @@ export default function HousingMap({
 
       rotationFrameRef.current = requestAnimationFrame(rotate);
     });
-
-
   }, [selectedId, mapLoaded, housings]);
 
   /* ── Toggle 3D ── */
@@ -259,11 +308,7 @@ export default function HousingMap({
     } else {
       map.easeTo({ pitch: DEFAULT_PITCH, duration: 800 });
       if (map.getLayer(BUILDING_LAYER_ID)) {
-        map.setPaintProperty(
-          BUILDING_LAYER_ID,
-          "fill-extrusion-opacity",
-          0.85
-        );
+        map.setPaintProperty(BUILDING_LAYER_ID, "fill-extrusion-opacity", 0.85);
       }
     }
     setIs3D(!is3D);
@@ -290,7 +335,7 @@ export default function HousingMap({
 
   return (
     <div className="housing-map-wrapper">
-      {/* Loading overlay */}
+      {/* Loading */}
       {!mapLoaded && (
         <div className="map-loading">
           <div className="map-loading-spinner" />
@@ -298,7 +343,7 @@ export default function HousingMap({
         </div>
       )}
 
-      {/* Map container */}
+      {/* Map canvas */}
       <div ref={mapContainerRef} className="map-container" />
 
       {/* Controls */}
@@ -338,8 +383,8 @@ export default function HousingMap({
         }
 
         .map-container {
-          width: 100%;
-          height: 100%;
+          position: absolute;
+          inset: 0;
         }
 
         /* Loading */
@@ -388,8 +433,6 @@ export default function HousingMap({
           justify-content: center;
           width: 2.25rem;
           height: 2.25rem;
-          min-height: 2.25rem;
-          min-width: 2.25rem;
           border-radius: 0.5rem;
           border: none;
           background: rgba(28, 38, 50, 0.85);
@@ -403,7 +446,6 @@ export default function HousingMap({
         .map-control-btn:hover {
           background: rgba(28, 38, 50, 0.95);
           color: #C9642A;
-          transform: scale(1.05);
         }
 
         .map-control-btn.active {
@@ -421,42 +463,7 @@ export default function HousingMap({
           color: white;
         }
 
-        /* Markers — minimal element for stable positioning */
-        .casa-map-marker {
-          line-height: 0;
-          cursor: pointer;
-          z-index: 1;
-        }
-
-        .casa-map-marker.active {
-          z-index: 60;
-        }
-
-        .marker-pin {
-          line-height: 0;
-          display: inline-flex;
-          align-items: center;
-          justify-content: center;
-          padding: 0.4rem;
-          border-radius: 50%;
-          background: ${BRAND_ORANGE};
-          border: 2.5px solid white;
-          color: white;
-          box-shadow: 0 2px 8px rgba(0,0,0,0.35);
-          transition: background-color 0.2s;
-        }
-
-        .casa-map-marker:hover .marker-pin {
-          background: #a8511e;
-        }
-
-        .casa-map-marker.active .marker-pin {
-          background: ${BRAND_DARK};
-          outline: 2.5px solid ${BRAND_ORANGE};
-          outline-offset: 2px;
-        }
-
-        /* Popup tooltip for marker hover */
+        /* Popup tooltip */
         .casa-marker-popup .maplibregl-popup-content {
           background: white;
           color: ${BRAND_DARK};
@@ -473,7 +480,7 @@ export default function HousingMap({
           border-top-color: white;
         }
 
-        /* Override MapLibre defaults for CASA branding */
+        /* Override MapLibre nav controls */
         .housing-map-wrapper .maplibregl-ctrl-group {
           background: rgba(28, 38, 50, 0.85) !important;
           border: none !important;
@@ -486,8 +493,6 @@ export default function HousingMap({
         .housing-map-wrapper .maplibregl-ctrl-group button {
           width: 2.25rem !important;
           height: 2.25rem !important;
-          min-height: 2.25rem !important;
-          min-width: 2.25rem !important;
           border: none !important;
           background: transparent !important;
         }
@@ -505,7 +510,6 @@ export default function HousingMap({
         }
 
         @media (prefers-reduced-motion: reduce) {
-          .marker-pin,
           .map-control-btn {
             transition: none !important;
           }

--- a/src/app/components/map/HousingMap.tsx
+++ b/src/app/components/map/HousingMap.tsx
@@ -402,13 +402,13 @@ export default function HousingMap({
           color: white;
         }
 
-        /* Markers */
+        /* Markers — stable positioning via intrinsic sizing (same as room-tba) */
         .casa-map-marker {
+          line-height: 0;
           cursor: pointer;
           position: relative;
           z-index: 1;
-          width: 2.25rem;
-          height: 2.25rem;
+          overflow: visible;
         }
 
         .casa-map-marker.active {
@@ -416,36 +416,45 @@ export default function HousingMap({
         }
 
         .marker-pin {
-          display: flex;
+          line-height: 0;
+          display: inline-flex;
           align-items: center;
           justify-content: center;
-          width: 2.25rem;
-          height: 2.25rem;
+          padding: 0.4rem;
           border-radius: 50%;
           background: ${BRAND_ORANGE};
           border: 2.5px solid white;
           color: white;
           box-shadow: 0 2px 8px rgba(0,0,0,0.35);
-          transition: transform 0.2s, background-color 0.2s;
+          transition: background-color 0.2s;
         }
 
-        .casa-map-marker:hover .marker-pin,
-        .casa-map-marker.active .marker-pin {
-          transform: scale(1.2);
+        .casa-map-marker:hover .marker-pin {
           background: #a8511e;
         }
 
         .casa-map-marker.active .marker-pin {
           background: ${BRAND_DARK};
+        }
+
+        .casa-map-marker.active .marker-pin::before {
+          content: "";
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          border-radius: 50%;
           outline: 2.5px solid ${BRAND_ORANGE};
           outline-offset: 2px;
         }
 
         .marker-label {
+          line-height: normal;
           position: absolute;
-          bottom: calc(100% + 0.4rem);
+          bottom: calc(100% + 0.5rem);
           left: 50%;
-          transform: translateX(-50%);
+          translate: -50% 0;
           background: white;
           color: ${BRAND_DARK};
           border-radius: 0.5rem;
@@ -454,6 +463,7 @@ export default function HousingMap({
           font-weight: 600;
           font-family: var(--font-geist-sans), sans-serif;
           white-space: nowrap;
+          width: max-content;
           box-shadow: 0 2px 8px rgba(0,0,0,0.15);
           opacity: 0;
           pointer-events: none;

--- a/src/app/lib/data/housing-data.ts
+++ b/src/app/lib/data/housing-data.ts
@@ -149,6 +149,7 @@ async function getHousingCardsData() {
 
     return {
       housingId: housing.housing_id.toString(),
+      housingIdNum: housing.housing_id,
       name: housing.housing_name,
       address: housing.housing_address,
       totalRooms,
@@ -156,7 +157,11 @@ async function getHousingCardsData() {
       vacantRooms,
       occupancyRate,
       minRent: housing.rent_price,
-      managerAccountNumber: housing.manager_account_number?.toString() || null, // ✅ Added
+      managerAccountNumber: housing.manager_account_number?.toString() || null,
+      latitude: housing.latitude,
+      longitude: housing.longitude,
+      image: housing.housing_image,
+      housingType: housing.housing_type,
     };
   });
 }


### PR DESCRIPTION
## Summary

Adds a MapLibre GL-powered interactive map to the student housing browse page, manager accommodations, and admin accommodations. Users can visually explore housing on a 3D map of the UPLB campus.

## Changes

### Map Integration
- **HousingMap component** — shared component at `components/map/HousingMap.tsx` using `maplibre-gl` with 3D building extrusions, housing markers, fly-to animations, and camera rotation
- **Student browse** — split-view layout with map fixed to the left half and search+cards scrolling on the right
- **Manager accommodations** — toggleable map panel above the accommodation cards list
- **Admin accommodations** — toggleable map panel above the dorm card grid via new `AdminAccommodationsContent` client component

### Data
- Seeded 14 real UPLB housing entries with actual campus coordinates:
  - 9 UP residence halls (Makiling, International House, Forestry, New Forestry, Women's, Men's, VetMed, New Dormitory, ATI-NTC)
  - 5 off-campus options (Centtro Residences, Copeland Heights, Raymundo Gate Apartments, Grove Student Boarding, Lopez Avenue Dormitory)
- Uploaded Unsplash housing images to Supabase storage and linked them to each entry
- Soft-deleted placeholder/test entries from the browse page
- Extended `getHousingCardsData` to return lat/lon, image, and housing type

### UI Fixes
- Card images now use a fixed 16:10 aspect ratio with `object-cover` for consistent display regardless of source dimensions
- Marker positioning uses intrinsic sizing (`line-height:0` + `padding`) to prevent drift during pan/zoom
- Map panel uses `position:fixed` on desktop so it stays at viewport height, independent of card count

### Responsive
- Desktop: side-by-side split (map left, content right)
- Mobile: stacked layout with collapsible map
- Toggle button to switch between map+cards and cards-only views

## Dependencies
- `maplibre-gl` added to package.json
- OSM Liberty map style at `public/map-style.json`