### PR TITLE
feat: dark mode (WIP - DO NOT MERGE)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "lucide-react": "^1.11.0",
         "maplibre-gl": "^5.24.0",
         "next": "16.2.4",
+        "next-themes": "^0.4.6",
         "react": "19.2.5",
         "react-dom": "19.2.5",
         "serwist": "^9.5.11",
@@ -4076,6 +4077,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lucide-react": "^1.11.0",
     "maplibre-gl": "^5.24.0",
     "next": "16.2.4",
+    "next-themes": "^0.4.6",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "serwist": "^9.5.11",

--- a/src/app/(main)/(landing)/GSSection.tsx
+++ b/src/app/(main)/(landing)/GSSection.tsx
@@ -58,7 +58,7 @@ export default function CTASection() {
         {/* Button */}
         <Link
           href="/register"
-          className="shrink-0 bg-white text-[#C9642A] text-sm font-semibold px-6 py-3 rounded-xl hover:bg-[#EDE9DE] transition-colors duration-200 whitespace-nowrap"
+          className="shrink-0 bg-white text-[#C9642A] text-sm font-semibold px-6 py-3 rounded-xl hover:bg-[var(--cream)] transition-colors duration-200 whitespace-nowrap"
         >
           Get Started Free
         </Link>

--- a/src/app/(main)/(landing)/TestimonialsSection.tsx
+++ b/src/app/(main)/(landing)/TestimonialsSection.tsx
@@ -80,7 +80,7 @@ export default function TestimonialsSection() {
     <section
       ref={sectionRef}
       id="testimonials"
-      className="bg-[#EDE9DE] py-20 px-8 md:px-20 overflow-hidden"
+      className="bg-[var(--cream)] py-20 px-8 md:px-20 overflow-hidden"
     >
       {/* Header */}
       <div ref={headerRef} className="mb-12 opacity-0 max-w-xl">
@@ -91,7 +91,7 @@ export default function TestimonialsSection() {
           Student Stories
         </p>
         <h2
-          className="text-4xl md:text-5xl font-bold text-[#1C2632] leading-tight"
+          className="text-4xl md:text-5xl font-bold text-[#1C2632] dark:text-[#EDE9DE] leading-tight"
           style={{ fontFamily: "'Playfair Display', serif" }}
         >
           What <em className="text-[#C9642A] italic">Works</em> Says
@@ -118,7 +118,7 @@ export default function TestimonialsSection() {
 
             {/* Quote text */}
             <p
-              className="text-sm leading-relaxed text-[#1C2632]/70 flex-1"
+              className="text-sm leading-relaxed text-[#1C2632]/70 dark:text-[#EDE9DE]/70 flex-1"
               style={{ fontFamily: "'IBM Plex Mono', monospace" }}
             >
               {t.quote}
@@ -134,12 +134,12 @@ export default function TestimonialsSection() {
                 </span>
               </div>
               <div>
-                <p className="text-sm font-semibold text-[#1C2632]">
+                <p className="text-sm font-semibold text-[#1C2632] dark:text-[#EDE9DE]">
                   {" "}
                   {t.name}{" "}
                 </p>
                 <p
-                  className="text-xs text-[#1C2632]/50"
+                  className="text-xs text-[#1C2632]/50 dark:text-[#EDE9DE]/50"
                   style={{ fontFamily: "'IBM Plex Mono', monospace" }}
                 >
                   {t.course}

--- a/src/app/(main)/(landing)/page.tsx
+++ b/src/app/(main)/(landing)/page.tsx
@@ -10,6 +10,7 @@ import HowItWorks from "./HowItWorksSection";
 import ServicesSection from "./ServicesSection";
 import ShowcaseSection from "./ShowcaseSection";
 import TestimonialsSection from "./TestimonialsSection";
+import ThemeToggle from "@/app/components/ui/ThemeToggle";
 
 // Mapping colors
 const colors = {
@@ -61,7 +62,8 @@ export default function LandingPage() {
         <div className="flex items-center">
           <Logo href={null} size={64} textClassName="text-[#1C2632]" />
         </div>
-        <div className="flex items-center gap-6">
+        <div className="flex items-center gap-4">
+          <ThemeToggle className="text-[#1C2632] dark:text-[#EDE9DE] rounded-full p-2 hover:bg-black/5 dark:hover:bg-white/10" />
           {isLoggedIn ? (
             <Link
               href={dashboardUrl}

--- a/src/app/(main)/(landing)/page.tsx
+++ b/src/app/(main)/(landing)/page.tsx
@@ -41,7 +41,7 @@ export default function LandingPage() {
     }
   }, []);
   return (
-    <div className="min-h-screen overflow-x-hidden font-family-name:var(--font-geist-sans) bg-[#EDE9DE] text-[#1C2632]">
+    <div className="min-h-screen overflow-x-hidden font-family-name:var(--font-geist-sans) bg-[var(--cream)] text-[#1C2632] dark:text-[#EDE9DE]">
       <div className="bg-[#1C2632] text-[#EDE9DE] py-2 px-4 text-center text-[10px] md:text-xs font-medium tracking-wide uppercase">
         Testing UPLB CASA? Read the{" "}
         <a

--- a/src/app/(main)/(landing)/page.tsx
+++ b/src/app/(main)/(landing)/page.tsx
@@ -136,7 +136,7 @@ export default function LandingPage() {
                 </Link>
                 <Link
                   href="#how"
-                  className="border border-[#1C2632]/20 text-[#1C2632] px-6 py-3 rounded-xl font-semibold text-sm hover:border-[#C9642A] hover:text-[#C9642A] transition-colors"
+                  className="border border-[#1C2632]/20 dark:border-[#EDE9DE]/20 text-[#1C2632] dark:text-[#EDE9DE] px-6 py-3 rounded-xl font-semibold text-sm hover:border-[#C9642A] hover:text-[#C9642A] transition-colors"
                 >
                   Learn More
                 </Link>

--- a/src/app/(main)/admin/accommodations/AdminAccommodationsContent.tsx
+++ b/src/app/(main)/admin/accommodations/AdminAccommodationsContent.tsx
@@ -75,7 +75,7 @@ export default function AdminAccommodationsContent({
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 w-full max-w-6xl mx-auto">
         {dormCards.length === 0 ? (
           <div className="w-full max-w-6xl mx-auto rounded-2xl border border-[#CEC7B0] bg-white px-8 py-14 text-center text-[#1C2632] shadow-sm">
-            <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-[#EDE9DE] text-[#8AABAC]">
+            <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-[var(--cream)] text-[#8AABAC]">
               0
             </div>
             <div className="text-lg font-semibold">No properties found</div>

--- a/src/app/(main)/admin/profile/[id]/page.tsx
+++ b/src/app/(main)/admin/profile/[id]/page.tsx
@@ -97,14 +97,14 @@ export default function AdminProfilePage() {
   }
 
   return (
-    <div className="flex min-h-screen bg-[#EDE9DE] font-[family-name:var(--font-geist-sans)]">
+    <div className="flex min-h-screen bg-[var(--cream)] font-[family-name:var(--font-geist-sans)]">
       {/* 1. LEFT SIDEBAR (Placeholder) */}
       <aside className="w-[280px] bg-[#1C2632] flex flex-col shrink-0"></aside>
 
       {/* 2. MAIN CONTENT AREA */}
       <main className="flex-1 flex flex-col">
         {/* Header Section */}
-        <header className="bg-[#EDE9DE] border-b border-[#1C2632]">
+        <header className="bg-[var(--cream)] border-b border-[#1C2632]">
           <div className="max-w-2xl ml-[15%] py-12 flex items-center gap-8">
             <div className="w-32 h-32 bg-[#1C2632] rounded-full flex shrink-0 items-center justify-center shadow-xl">
               <span className="text-[#EDE9DE] text-4xl font-bold">

--- a/src/app/(main)/manage/layout.tsx
+++ b/src/app/(main)/manage/layout.tsx
@@ -13,6 +13,8 @@ export const metadata: Metadata = {
     "Manager panel for managing properties, applications, and tenants.",
 };
 
+import ThemeToggle from "@/app/components/ui/ThemeToggle";
+
 export default async function ManageLayout({
   children,
 }: {
@@ -37,38 +39,38 @@ export default async function ManageLayout({
             <nav className="hidden md:flex items-center gap-6 border-l border-gray-700 pl-8 font-[family-name:var(--font-geist-sans)]">
               <Link
                 href="/manage"
-                className="text-[#EDE9DE] hover:opacity-80 transition-opacity py-3"
+                className="text-[#EDE9DE] hover:opacity-80 transition-opacity py-3 rounded-md px-2"
               >
                 Dashboard
               </Link>
               <Link
                 href="/manage/accommodations"
-                className="text-[#EDE9DE] hover:opacity-80 transition-opacity py-3"
+                className="text-[#EDE9DE] hover:opacity-80 transition-opacity py-3 rounded-md px-2"
               >
                 Accommodations
               </Link>
               <Link
                 href="/manage/applications"
-                className="text-[#EDE9DE] hover:opacity-80 transition-opacity py-3"
+                className="text-[#EDE9DE] hover:opacity-80 transition-opacity py-3 rounded-md px-2"
               >
                 Applications
               </Link>
               <Link
                 href="/manage/complaints"
-                className="text-[#EDE9DE] hover:opacity-80 transition-opacity py-3"
+                className="text-[#EDE9DE] hover:opacity-80 transition-opacity py-3 rounded-md px-2"
               >
                 Complaints
               </Link>
               <Link
                 href="/manage/logs"
-                className="text-[#EDE9DE] hover:opacity-80 transition-opacity py-3"
+                className="text-[#EDE9DE] hover:opacity-80 transition-opacity py-3 rounded-md px-2"
               >
                 Audit Logs
               </Link>
             </nav>
           </div>
 
-          <div className="flex items-center gap-6 text-sm">
+          <div className="flex items-center gap-2 md:gap-4 text-sm">
             {/* Mobile Nav Link */}
             <Link
               href="/manage"
@@ -77,9 +79,11 @@ export default async function ManageLayout({
               Dashboard
             </Link>
 
+            <ThemeToggle className="rounded-full p-2 hover:bg-white/10" />
+
             <button
               type="button"
-              className="text-[#EDE9DE] hover:opacity-80 transition-opacity flex items-center justify-center"
+              className="text-[#EDE9DE] hover:bg-white/10 transition-colors flex items-center justify-center rounded-full p-2"
             >
               <Bell size={22} strokeWidth={2} />
             </button>

--- a/src/app/(main)/manage/profile/[id]/page.tsx
+++ b/src/app/(main)/manage/profile/[id]/page.tsx
@@ -188,7 +188,7 @@ export default function ManagerProfilePage() {
 
   return (
     <div className="flex flex-col min-h-screen bg-[#1C2632] font-[family-name:var(--font-geist-sans)]">
-      <div className="mx-auto w-[90vw] flex-1 bg-[#EDE9DE] p-10 flex gap-12">
+      <div className="mx-auto w-[90vw] flex-1 bg-[var(--cream)] p-10 flex gap-12">
         {/* Left Card Sidebar */}
         <div className="w-1/3 bg-white/50 border border-[#E3AF64] rounded-[2rem] p-8 flex flex-col items-center shadow-sm">
           <div className="w-32 h-32 mb-6">

--- a/src/app/(main)/student/(dashboard)/SearchBar.tsx
+++ b/src/app/(main)/student/(dashboard)/SearchBar.tsx
@@ -24,7 +24,7 @@ export default function SearchBar() {
   }
 
   return (
-    <div className="flex flex-row items-center gap-3 bg-[#EDE9DE] w-[90vw] h-[7vh] p-3 mx-auto m-2 rounded-xl relative">
+    <div className="flex flex-row items-center gap-3 bg-[var(--cream)] w-[90vw] h-[7vh] p-3 mx-auto m-2 rounded-xl relative">
       {/* Filter Section */}
       <div className="relative">
         <button

--- a/src/app/(main)/student/(dashboard)/_components/AssignedDashboard.tsx
+++ b/src/app/(main)/student/(dashboard)/_components/AssignedDashboard.tsx
@@ -6,7 +6,7 @@ export default function AssignedDashboard(
 
   const hStyle =
     "justify-center text-white text-lg font-semibold font-[family-name:var(--font-DM_Sans)]";
-  const tStyle = "text-black text-lg font-[family-name:var(--font-DM_Sans)]";
+  const tStyle = "text-black dark:text-[#EDE9DE] text-lg font-[family-name:var(--font-DM_Sans)]";
 
   function getApplication() {
     return userHousingDetails?.application;
@@ -18,11 +18,11 @@ export default function AssignedDashboard(
 
   return (
     <div className="w-full flex-1 flex flex-col justify-start items-start gap-4">
-      <div className="w-full h-auto min-h-9 px-4 md:px-9 py-2 bg-gray-800 rounded-full shadow-[0px_2px_4px_0px_rgba(0,0,0,0.25)] inline-flex justify-start items-center gap-2.5 overflow-hidden">
+      <div className="w-full h-auto min-h-9 px-4 md:px-9 py-2 bg-gray-800 dark:bg-gray-900 rounded-full shadow-[0px_2px_4px_0px_rgba(0,0,0,0.25)] inline-flex justify-start items-center gap-2.5 overflow-hidden">
         <div className={hStyle}>Hello, {userName}!</div>
       </div>
-      <div className="w-full flex-1 bg-stone-200 rounded-2xl shadow-[0px_2px_4px_0px_rgba(0,0,0,0.25)] flex flex-col justify-start items-start overflow-hidden">
-        <div className="self-stretch h-auto min-h-9 px-4 md:px-9 py-2 bg-gray-800 inline-flex justify-start items-center gap-2.5 overflow-hidden">
+      <div className="w-full flex-1 bg-stone-200 dark:bg-[#1C2632] rounded-2xl shadow-[0px_2px_4px_0px_rgba(0,0,0,0.25)] flex flex-col justify-start items-start overflow-hidden">
+        <div className="self-stretch h-auto min-h-9 px-4 md:px-9 py-2 bg-gray-800 dark:bg-gray-900 inline-flex justify-start items-center gap-2.5 overflow-hidden">
           <div className={hStyle}>Housing Information</div>
         </div>
         <div className="self-stretch flex-1 px-4 md:px-9 py-4">
@@ -56,8 +56,8 @@ export default function AssignedDashboard(
           </span>
         </div>
       </div>
-      <div className="w-full flex-1 bg-stone-200 rounded-2xl shadow-[0px_2px_4px_0px_rgba(0,0,0,0.25)] flex flex-col justify-start items-center overflow-hidden">
-        <div className="self-stretch h-auto min-h-9 px-4 md:px-9 py-2 bg-gray-800 inline-flex justify-start items-center gap-2.5 overflow-hidden">
+      <div className="w-full flex-1 bg-stone-200 dark:bg-[#1C2632] rounded-2xl shadow-[0px_2px_4px_0px_rgba(0,0,0,0.25)] flex flex-col justify-start items-center overflow-hidden">
+        <div className="self-stretch h-auto min-h-9 px-4 md:px-9 py-2 bg-gray-800 dark:bg-gray-900 inline-flex justify-start items-center gap-2.5 overflow-hidden">
           <div className={hStyle}>Billing Status</div>
         </div>
         <div className="self-stretch flex-1 px-4 md:px-9 py-4" />

--- a/src/app/(main)/student/(dashboard)/_components/NotAssignedDashboard.tsx
+++ b/src/app/(main)/student/(dashboard)/_components/NotAssignedDashboard.tsx
@@ -8,7 +8,7 @@ export default function NotAssignedDashboard(
 
   const hStyle =
     "justify-center text-white text-lg font-semibold font-[family-name:var(--font-DM_Sans)]";
-  const tStyle = "text-black text-lg font-[family-name:var(--font-DM_Sans)]";
+  const tStyle = "text-black dark:text-[#EDE9DE] text-lg font-[family-name:var(--font-DM_Sans)]";
   const checkIcon = (
     <CircleCheckBig className="w-24 h-24 text-green-700" strokeWidth={2.2} />
   );
@@ -36,11 +36,11 @@ export default function NotAssignedDashboard(
 
   return (
     <div className="w-full flex-1 flex flex-col justify-start items-start gap-4">
-      <div className="w-full h-auto min-h-9 px-4 md:px-9 py-2 bg-gray-800 rounded-full shadow-[0px_2px_4px_0px_rgba(0,0,0,0.25)] inline-flex justify-start items-center gap-2.5 overflow-hidden">
+      <div className="w-full h-auto min-h-9 px-4 md:px-9 py-2 bg-gray-800 dark:bg-gray-900 rounded-full shadow-[0px_2px_4px_0px_rgba(0,0,0,0.25)] inline-flex justify-start items-center gap-2.5 overflow-hidden">
         <div className={hStyle}>Welcome, {userName}</div>
       </div>
-      <div className="w-full flex-1 bg-stone-200 rounded-2xl shadow-[0px_2px_4px_0px_rgba(0,0,0,0.25)] flex flex-col justify-start items-start overflow-hidden">
-        <div className="self-stretch h-auto min-h-9 px-4 md:px-9 py-2 bg-gray-800 inline-flex justify-start items-center gap-2.5 overflow-hidden">
+      <div className="w-full flex-1 bg-stone-200 dark:bg-[#1C2632] rounded-2xl shadow-[0px_2px_4px_0px_rgba(0,0,0,0.25)] flex flex-col justify-start items-start overflow-hidden">
+        <div className="self-stretch h-auto min-h-9 px-4 md:px-9 py-2 bg-gray-800 dark:bg-gray-900 inline-flex justify-start items-center gap-2.5 overflow-hidden">
           <div className={hStyle}>Application Status</div>
         </div>
         <div className="self-stretch flex-1 px-4 md:px-24 py-6 md:py-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 items-center overflow-hidden">
@@ -86,8 +86,8 @@ export default function NotAssignedDashboard(
           </div>
         </div>
       </div>
-      <div className="w-full flex-1 bg-stone-200 rounded-2xl shadow-[0px_2px_4px_0px_rgba(0,0,0,0.25)] flex flex-col justify-start items-start overflow-hidden">
-        <div className="self-stretch h-auto min-h-9 px-4 md:px-9 py-2 bg-gray-800 inline-flex justify-start items-center gap-2.5 overflow-hidden">
+      <div className="w-full flex-1 bg-stone-200 dark:bg-[#1C2632] rounded-2xl shadow-[0px_2px_4px_0px_rgba(0,0,0,0.25)] flex flex-col justify-start items-start overflow-hidden">
+        <div className="self-stretch h-auto min-h-9 px-4 md:px-9 py-2 bg-gray-800 dark:bg-gray-900 inline-flex justify-start items-center gap-2.5 overflow-hidden">
           <div className={hStyle}>Application Details</div>
         </div>
         <div className="self-stretch flex-1 px-9 py-4">

--- a/src/app/(main)/student/(dashboard)/page.tsx
+++ b/src/app/(main)/student/(dashboard)/page.tsx
@@ -18,7 +18,7 @@ export default async function DashboardPage() {
 
   if (!getValue) {
     return (
-      <div className="w-full min-h-screen bg-[#EDE9DE] flex flex-col">
+      <div className="w-full min-h-screen bg-[var(--cream)] flex flex-col">
         <StudentNavBar path={"Dashboard"} />
         <div className="w-full max-w-7xl mx-auto flex-1 px-4 md:px-9 py-4 flex flex-col justify-center items-center gap-4 overflow-hidden">
           <StateMessage
@@ -39,7 +39,7 @@ export default async function DashboardPage() {
   > | null = null;
 
   const renderErrorState = (content: React.ReactNode, isCentered = true) => (
-    <div className="w-full min-h-screen bg-[#EDE9DE] flex flex-col">
+    <div className="w-full min-h-screen bg-[var(--cream)] flex flex-col">
       <StudentNavBar path={"Dashboard"} userId={account_number} />
       <div className={`w-full max-w-7xl mx-auto flex-1 px-4 md:px-9 py-4 flex flex-col items-center gap-4 overflow-hidden ${isCentered ? 'justify-center' : 'justify-start'}`}>
         {content}
@@ -93,7 +93,7 @@ export default async function DashboardPage() {
 
   return (
     // MAIN PAGE
-    <div className="w-full min-h-screen bg-[#EDE9DE] flex flex-col">
+    <div className="w-full min-h-screen bg-[var(--cream)] flex flex-col">
       {/* NAVBAR */}
       <StudentNavBar
         path={"Dashboard"}

--- a/src/app/(main)/student/_components/StudentNavBar.tsx
+++ b/src/app/(main)/student/_components/StudentNavBar.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { Bell } from "lucide-react";
 import Logo from "@/app/components/Logo";
 import Avatar from "@/app/components/Avatar";
+import ThemeToggle from "@/app/components/ui/ThemeToggle";
 
 interface StudentNavbarProps {
   path: string;
@@ -43,6 +44,7 @@ export default function StudentNavBar({
 					</div>
 
 				<div className="flex items-center gap-6">
+					<ThemeToggle />
 					<button 
 						suppressHydrationWarning
 						className="flex items-center justify-center text-[#EDE9DE] hover:opacity-80 transition-opacity"

--- a/src/app/(main)/student/_components/StudentNavBar.tsx
+++ b/src/app/(main)/student/_components/StudentNavBar.tsx
@@ -33,21 +33,21 @@ export default function StudentNavBar({
 						<Logo size={28} href="/" />
 
 						<nav className="hidden md:flex items-center gap-6 border-l border-gray-700 pl-8 h-7 font-[family-name:var(--font-geist-sans)]">
-							<Link href="/student" className="text-[#EDE9DE] hover:opacity-80 transition-opacity flex items-center h-full text-m leading-none">
+							<Link href="/student" className="text-[#EDE9DE] hover:opacity-80 transition-opacity flex items-center h-full text-m leading-none rounded-md px-2 focus-visible:-ml-2">
 								Dashboard
 							</Link>
-							<Link href="/student/browse" className="text-[#EDE9DE] hover:opacity-80 transition-opacity flex items-center h-full text-m leading-none">
+							<Link href="/student/browse" className="text-[#EDE9DE] hover:opacity-80 transition-opacity flex items-center h-full text-m leading-none rounded-md px-2">
 								Browse
 							</Link>
 						</nav>
 						
 					</div>
 
-				<div className="flex items-center gap-6">
-					<ThemeToggle />
+				<div className="flex items-center gap-2 md:gap-4">
+					<ThemeToggle className="rounded-full p-2 hover:bg-white/10" />
 					<button 
 						suppressHydrationWarning
-						className="flex items-center justify-center text-[#EDE9DE] hover:opacity-80 transition-opacity"
+						className="flex items-center justify-center text-[#EDE9DE] hover:bg-white/10 transition-colors rounded-full p-2"
 						>
 							<Bell className="h-6 w-6" strokeWidth={2} />
 					</button>

--- a/src/app/(main)/student/browse/_components/SearchBar.tsx
+++ b/src/app/(main)/student/browse/_components/SearchBar.tsx
@@ -24,7 +24,7 @@ export default function SearchBar() {
   }
 
   return (
-    <div className="flex flex-row items-center gap-3 bg-[#EDE9DE] w-[90vw] h-[7vh] p-3 mx-auto m-2 rounded-xl relative">
+    <div className="flex flex-row items-center gap-3 bg-[var(--cream)] w-[90vw] h-[7vh] p-3 mx-auto m-2 rounded-xl relative">
       {/* Filter Section */}
       <div className="relative">
         <button

--- a/src/app/(main)/student/browse/apply/_components/ApplyFormContent.tsx
+++ b/src/app/(main)/student/browse/apply/_components/ApplyFormContent.tsx
@@ -122,7 +122,7 @@ export function ApplyFormContent() {
   const headerName = dormData?.housing_name || "Housing";
 
   return (
-    <div className="w-full max-w-7xl mx-auto mt-4 md:mt-8 flex-1 bg-[#EDE9DE] p-6 md:p-10 rounded-t-[20px] font-[family-name:var(--font-geist-sans)] shadow-inner">
+    <div className="w-full max-w-7xl mx-auto mt-4 md:mt-8 flex-1 bg-[var(--cream)] p-6 md:p-10 rounded-t-[20px] font-[family-name:var(--font-geist-sans)] shadow-inner">
       {/* Back Button */}
       <button
         onClick={() => router.back()}

--- a/src/app/(main)/student/browse/apply/page.tsx
+++ b/src/app/(main)/student/browse/apply/page.tsx
@@ -10,14 +10,14 @@ export const metadata: Metadata = {
 
 export default function ApplyPage() {
   return (
-    <div className="w-full min-h-screen bg-[#EDE9DE] flex flex-col">
+    <div className="w-full min-h-screen bg-[var(--cream)] flex flex-col">
       {/* Header */}
       <StudentNavBar path="Housing Browser > Apply" />
 
       {/* Application */}
       <Suspense
         fallback={
-          <div className="w-full max-w-7xl mx-auto mt-4 md:mt-8 flex-1 bg-[#EDE9DE] p-6 md:p-10 rounded-t-[20px] shadow-inner">
+          <div className="w-full max-w-7xl mx-auto mt-4 md:mt-8 flex-1 bg-[var(--cream)] p-6 md:p-10 rounded-t-[20px] shadow-inner">
             Loading...
           </div>
         }

--- a/src/app/(main)/student/browse/page.tsx
+++ b/src/app/(main)/student/browse/page.tsx
@@ -66,7 +66,7 @@ export default async function DormBrowsePage({
   }));
 
   return (
-    <div className="w-full min-h-screen bg-[#EDE9DE] flex flex-col">
+    <div className="w-full min-h-screen bg-[var(--cream)] flex flex-col">
       <StudentNavBar
         path={"Housing Browser"}
         userId={currUser?.account_number}

--- a/src/app/(main)/student/complaints/page.tsx
+++ b/src/app/(main)/student/complaints/page.tsx
@@ -45,7 +45,7 @@ export default function StudentComplaintsPage() {
   };
 
   return (
-    <div className="w-full min-h-screen bg-[#EDE9DE] flex flex-col">
+    <div className="w-full min-h-screen bg-[var(--cream)] flex flex-col">
       <StudentNavBar path="Complaints" />
       <div className="w-full max-w-2xl mx-auto mt-8 flex-1 bg-white p-6 md:p-10 rounded-t-[20px] font-[family-name:var(--font-geist-sans)] shadow-inner border border-[#E3E3E3]">
         <h1 className="text-2xl font-bold mb-4 text-[#1C2632]">

--- a/src/app/(main)/student/profile/[id]/page.tsx
+++ b/src/app/(main)/student/profile/[id]/page.tsx
@@ -267,11 +267,11 @@ export default function StudentProfilePage() {
   const studentAcademic = studentDetails?.student_academic;
 
   return (
-    <div className="flex flex-col min-h-screen bg-[#EDE9DE] font-[family-name:var(--font-geist-sans)]">
+    <div className="flex flex-col min-h-screen bg-[var(--cream)] font-[family-name:var(--font-geist-sans)]">
       <StudentNavBar path="Student Profile" userId={Number(accountNumber)} />
 
       {/* Main Content*/}
-      <div className="w-full max-w-7xl mx-auto flex-1 bg-[#EDE9DE] p-6 md:p-10 flex flex-col md:flex-row gap-8 md:gap-12 shadow-inner">
+      <div className="w-full max-w-7xl mx-auto flex-1 bg-[var(--cream)] p-6 md:p-10 flex flex-col md:flex-row gap-8 md:gap-12 shadow-inner">
         {/* Left Card Sidebar */}
         <div className="w-full md:w-80 lg:w-1/4 shrink-0 bg-white/50 border border-[#E3AF64] rounded-[2rem] p-6 md:p-8 flex flex-col items-center shadow-sm h-fit">
           {/* Profile Circle */}

--- a/src/app/components/admin/pageheader.tsx
+++ b/src/app/components/admin/pageheader.tsx
@@ -26,6 +26,9 @@ function toTitleCaseFromPath(pathname: string) {
     .replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+import ThemeToggle from "@/app/components/ui/ThemeToggle";
+
+// ... skipping to the export default function ...
 export default function PageHeader({ title, date }: PageHeaderProps) {
   const pathname = usePathname();
 
@@ -47,33 +50,21 @@ export default function PageHeader({ title, date }: PageHeaderProps) {
 
   return (
     <div
+      className="flex justify-between items-center border-b border-gray-200 dark:border-gray-700"
       style={{
         padding: "28px 32px 20px",
-        borderBottom: "1px solid #e2e5ea",
         fontFamily: "'DM Sans', sans-serif",
       }}
     >
-      <h1
-        style={{
-          fontSize: 26,
-          fontWeight: 700,
-          color: "#1C2632",
-          margin: "0 0 4px",
-          lineHeight: 1.2,
-        }}
-      >
-        {resolvedTitle}
-      </h1>
-      <p
-        style={{
-          fontSize: 11,
-          color: "#9aa3b0",
-          margin: 0,
-          letterSpacing: "0.02em",
-        }}
-      >
-        {formattedDate}
-      </p>
+      <div>
+        <h1 className="text-[26px] font-bold text-[#1C2632] dark:text-[#EDE9DE] m-0 mb-1 leading-[1.2]">
+          {resolvedTitle}
+        </h1>
+        <p className="text-[11px] text-[#9aa3b0] dark:text-[#9aa3b0]/80 m-0 tracking-[0.02em]">
+          {formattedDate}
+        </p>
+      </div>
+      <ThemeToggle className="text-[#1C2632] dark:text-[#EDE9DE] bg-gray-100 dark:bg-gray-800 p-2 rounded-xl" />
     </div>
   );
 }

--- a/src/app/components/ui/ThemeToggle.tsx
+++ b/src/app/components/ui/ThemeToggle.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+
+export default function ThemeToggle() {
+  const [mounted, setMounted] = useState(false);
+  const { theme, setTheme } = useTheme();
+
+  // useEffect only runs on the client, so now we can safely show the UI
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null; // Prevent hydration mismatch
+  }
+
+  return (
+    <button
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      className="fixed bottom-6 right-6 p-4 rounded-full bg-white dark:bg-[#1c2632] shadow-lg border-2 border-[#e3af64] dark:border-[#567375] text-[#1c2632] dark:text-[#ede9de] hover:scale-110 transition-transform z-50 flex items-center justify-center"
+      aria-label="Toggle Dark Mode"
+    >
+      {theme === "dark" ? <Sun size={24} /> : <Moon size={24} />}
+    </button>
+  );
+}

--- a/src/app/components/ui/ThemeToggle.tsx
+++ b/src/app/components/ui/ThemeToggle.tsx
@@ -4,7 +4,7 @@ import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 import { Moon, Sun } from "lucide-react";
 
-export default function ThemeToggle() {
+export default function ThemeToggle({ className = "" }: { className?: string }) {
   const [mounted, setMounted] = useState(false);
   const { theme, setTheme } = useTheme();
 
@@ -20,8 +20,9 @@ export default function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-      className="fixed bottom-6 right-6 p-4 rounded-full bg-white dark:bg-[#1c2632] shadow-lg border-2 border-[#e3af64] dark:border-[#567375] text-[#1c2632] dark:text-[#ede9de] hover:scale-110 transition-transform z-50 flex items-center justify-center"
+      className={`flex items-center justify-center text-[#EDE9DE] hover:opacity-80 transition-opacity ${className}`}
       aria-label="Toggle Dark Mode"
+      suppressHydrationWarning
     >
       {theme === "dark" ? <Sun size={24} /> : <Moon size={24} />}
     </button>

--- a/src/app/components/ui/page-loading.tsx
+++ b/src/app/components/ui/page-loading.tsx
@@ -9,16 +9,16 @@ export default function PageLoading({
 }) {
   const isOverlay = overlay || variant === 'overlay';
   
-  let containerClass = "min-h-screen w-full flex items-center justify-center bg-[#EDE9DE]";
+  let containerClass = "min-h-screen w-full flex items-center justify-center bg-[var(--cream)]";
   if (isOverlay) {
     containerClass = "fixed inset-0 z-[60] flex items-center justify-center bg-black/40 backdrop-blur-sm";
   } else if (variant === 'container') {
-    containerClass = "absolute inset-0 z-50 flex items-center justify-center bg-[#EDE9DE]";
+    containerClass = "absolute inset-0 z-50 flex items-center justify-center bg-[var(--cream)]";
   }
 
   return (
     <div className={containerClass}>
-      <div className={`flex flex-col items-center gap-6 ${isOverlay ? 'bg-[#EDE9DE] p-10 rounded-[20px] shadow-2xl border border-white/20' : ''}`}>
+      <div className={`flex flex-col items-center gap-6 ${isOverlay ? 'bg-[var(--cream)] p-10 rounded-[20px] shadow-2xl border border-white/20' : ''}`}>
         {/* Animated house icon — built stroke by stroke */}
         <div className="relative w-16 h-16">
           <svg

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,10 +22,88 @@
 .dark {
   --background: #111820;
   --foreground: #ede9de;
+  --cream: #111820;
+  --dark-blue: #0d1219;
   
   --text-aaa-blue: #ede9de;
-  --text-aaa-teal: #e3af64;
+  --text-aaa-teal: #8aadaf;
   --text-aaa-orange: #e3af64;
+
+  /* Surface colors for cards/modals in dark mode */
+  --surface: #1c2632;
+  --surface-raised: #243040;
+  --border-subtle: rgba(237, 233, 222, 0.1);
+}
+
+:root {
+  --surface: #ffffff;
+  --surface-raised: #f5f5f0;
+  --border-subtle: rgba(28, 38, 50, 0.1);
+}
+
+/* ─── Dark Mode: Page backgrounds ─── */
+.dark [class*="bg-[#EDE9DE]"],
+.dark [class*="bg-[#ede9de]"] {
+  background-color: var(--background) !important;
+}
+
+/* ─── Dark Mode: Card/container backgrounds ─── */
+.dark [class*="bg-white"] {
+  background-color: var(--surface) !important;
+}
+.dark [class*="bg-stone-200"],
+.dark [class*="bg-stone-50"],
+.dark [class*="bg-gray-50"],
+.dark [class*="bg-gray-100"] {
+  background-color: var(--surface) !important;
+}
+.dark [class*="bg-yellow-50"] {
+  background-color: var(--surface) !important;
+}
+
+/* ─── Dark Mode: Text ─── */
+.dark [class*="text-black"],
+.dark [class*="text-[#1C2632]"],
+.dark [class*="text-[#1c2632]"],
+.dark [class*="text-gray-900"],
+.dark [class*="text-gray-800"],
+.dark [class*="text-gray-700"] {
+  color: var(--foreground) !important;
+}
+.dark [class*="text-gray-600"],
+.dark [class*="text-gray-500"] {
+  color: #9aa3b0 !important;
+}
+
+/* ─── Dark Mode: Borders ─── */
+.dark [class*="border-gray-200"],
+.dark [class*="border-gray-100"],
+.dark [class*="border-stone-200"],
+.dark [class*="border-[#CEC7B0]"],
+.dark [class*="border-[#E3AF64]"] {
+  border-color: rgba(237, 233, 222, 0.15) !important;
+}
+
+/* ─── Dark Mode: Inputs ─── */
+.dark input,
+.dark select,
+.dark textarea {
+  background-color: var(--surface-raised) !important;
+  color: var(--foreground) !important;
+  border-color: rgba(237, 233, 222, 0.15) !important;
+}
+.dark input::placeholder,
+.dark select::placeholder,
+.dark textarea::placeholder {
+  color: #6e7a8a !important;
+}
+
+/* ─── Dark Mode: Scrollbar ─── */
+.dark ::-webkit-scrollbar-thumb {
+  background-color: #567375;
+}
+.dark ::-webkit-scrollbar-thumb:hover {
+  background-color: #c9642a;
 }
 
 @theme inline {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,9 +65,8 @@ span a {
 }
 
 *:focus-visible {
-  outline: 3px solid var(--text-aaa-blue) !important;
-  outline-offset: 2px !important;
-  transition: outline-offset 0.1s ease;
+  outline: 2px solid var(--dark-orange) !important;
+  outline-offset: 3px !important;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   --background: #ede9de;
   --foreground: #1c2632;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,68 +28,47 @@
   --text-aaa-blue: #ede9de;
   --text-aaa-teal: #8aadaf;
   --text-aaa-orange: #e3af64;
-
-  /* Surface colors for cards/modals in dark mode */
-  --surface: #1c2632;
-  --surface-raised: #243040;
-  --border-subtle: rgba(237, 233, 222, 0.1);
 }
 
-:root {
-  --surface: #ffffff;
-  --surface-raised: #f5f5f0;
-  --border-subtle: rgba(28, 38, 50, 0.1);
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
 }
 
-/* ─── Dark Mode: Page backgrounds ─── */
-.dark [class*="bg-[#EDE9DE]"],
-.dark [class*="bg-[#ede9de]"] {
-  background-color: var(--background) !important;
-}
+/* ─── Dark Mode: Override Tailwind color variables ─── */
+/* This is the correct approach for Tailwind v4: override the
+   CSS custom properties that Tailwind's utility classes reference. */
+.dark {
+  /* Backgrounds */
+  --color-white: #1c2632;
+  --color-stone-50: #1c2632;
+  --color-stone-200: #1c2632;
+  --color-gray-50: #1c2632;
+  --color-gray-100: #1c2632;
+  --color-gray-200: #243040;
+  --color-yellow-50: #1c2632;
 
-/* ─── Dark Mode: Card/container backgrounds ─── */
-.dark [class*="bg-white"] {
-  background-color: var(--surface) !important;
-}
-.dark [class*="bg-stone-200"],
-.dark [class*="bg-stone-50"],
-.dark [class*="bg-gray-50"],
-.dark [class*="bg-gray-100"] {
-  background-color: var(--surface) !important;
-}
-.dark [class*="bg-yellow-50"] {
-  background-color: var(--surface) !important;
-}
+  /* Text */
+  --color-black: #ede9de;
+  --color-gray-900: #ede9de;
+  --color-gray-800: #d5d0c3;
+  --color-gray-700: #c0bab0;
+  --color-gray-600: #9aa3b0;
+  --color-gray-500: #7d8694;
 
-/* ─── Dark Mode: Text ─── */
-.dark [class*="text-black"],
-.dark [class*="text-[#1C2632]"],
-.dark [class*="text-[#1c2632]"],
-.dark [class*="text-gray-900"],
-.dark [class*="text-gray-800"],
-.dark [class*="text-gray-700"] {
-  color: var(--foreground) !important;
-}
-.dark [class*="text-gray-600"],
-.dark [class*="text-gray-500"] {
-  color: #9aa3b0 !important;
-}
-
-/* ─── Dark Mode: Borders ─── */
-.dark [class*="border-gray-200"],
-.dark [class*="border-gray-100"],
-.dark [class*="border-stone-200"],
-.dark [class*="border-[#CEC7B0]"],
-.dark [class*="border-[#E3AF64]"] {
-  border-color: rgba(237, 233, 222, 0.15) !important;
+  /* Borders */
+  --color-gray-300: rgba(237, 233, 222, 0.2);
+  --color-stone-400: rgba(237, 233, 222, 0.25);
 }
 
 /* ─── Dark Mode: Inputs ─── */
 .dark input,
 .dark select,
 .dark textarea {
-  background-color: var(--surface-raised) !important;
-  color: var(--foreground) !important;
+  background-color: #243040 !important;
+  color: #ede9de !important;
   border-color: rgba(237, 233, 222, 0.15) !important;
 }
 .dark input::placeholder,
@@ -104,13 +83,6 @@
 }
 .dark ::-webkit-scrollbar-thumb:hover {
   background-color: #c9642a;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
 }
 
 html, body {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,31 +18,12 @@
 }
 
 .dark {
-  --background: #0f151c; /* Even darker blue for true dark mode */
+  --background: #111820;
   --foreground: #ede9de;
   
   --text-aaa-blue: #ede9de;
   --text-aaa-teal: #e3af64;
   --text-aaa-orange: #e3af64;
-}
-
-/* Global utility overrides for "easyyy" dark mode implementation */
-.dark .bg-white {
-  background-color: #1c2632 !important;
-  color: #ede9de !important;
-}
-.dark .bg-gray-50, .dark .bg-stone-50, .dark .bg-zinc-50 {
-  background-color: #1c2632 !important;
-  color: #ede9de !important;
-}
-.dark .text-gray-900, .dark .text-black, .dark .text-\[\#1C2632\] {
-  color: #ede9de !important;
-}
-.dark .border-gray-200, .dark .border-stone-200, .dark .border-zinc-200 {
-  border-color: #567375 !important;
-}
-.dark .bg-gray-100 {
-  background-color: #2f4a4c !important;
 }
 
 @theme inline {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #5a056f;
+  --background: #ede9de;
+  --foreground: #1c2632;
 
   /* Original color palette (used for backgrounds/decoration) */
   --dark-blue: #1c2632;
@@ -17,18 +17,39 @@
   --text-aaa-orange: #8b3e15;
 }
 
+.dark {
+  --background: #0f151c; /* Even darker blue for true dark mode */
+  --foreground: #ede9de;
+  
+  --text-aaa-blue: #ede9de;
+  --text-aaa-teal: #e3af64;
+  --text-aaa-orange: #e3af64;
+}
+
+/* Global utility overrides for "easyyy" dark mode implementation */
+.dark .bg-white {
+  background-color: #1c2632 !important;
+  color: #ede9de !important;
+}
+.dark .bg-gray-50, .dark .bg-stone-50, .dark .bg-zinc-50 {
+  background-color: #1c2632 !important;
+  color: #ede9de !important;
+}
+.dark .text-gray-900, .dark .text-black, .dark .text-\[\#1C2632\] {
+  color: #ede9de !important;
+}
+.dark .border-gray-200, .dark .border-stone-200, .dark .border-zinc-200 {
+  border-color: #567375 !important;
+}
+.dark .bg-gray-100 {
+  background-color: #2f4a4c !important;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #4f0f0f;
-    --foreground: #ededed;
-  }
 }
 
 html, body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,17 +31,23 @@ export const viewport: Viewport = {
   themeColor: "#1C2632",
 };
 
+import { Providers } from "./providers";
+import ThemeToggle from "@/app/components/ui/ThemeToggle";
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen overflow-x-hidden`}
       >
-        {children}
+        <Providers>
+          {children}
+          <ThemeToggle />
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,6 @@ export const viewport: Viewport = {
 };
 
 import { Providers } from "./providers";
-import ThemeToggle from "@/app/components/ui/ThemeToggle";
 
 export default function RootLayout({
   children,
@@ -46,7 +45,6 @@ export default function RootLayout({
       >
         <Providers>
           {children}
-          <ThemeToggle />
         </Providers>
       </body>
     </html>

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -5,7 +5,7 @@ import { WifiOff } from "lucide-react";
 
 export default function OfflinePage() {
   return (
-    <div className="min-h-screen bg-[#EDE9DE] flex items-center justify-center p-6">
+    <div className="min-h-screen bg-[var(--cream)] flex items-center justify-center p-6">
       <div className="text-center max-w-md">
         <div className="w-20 h-20 rounded-full bg-[#1C2632] flex items-center justify-center mx-auto mb-6">
           <WifiOff size={36} className="text-[#C9642A]" />

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { ThemeProvider } from "next-themes";
+import { ReactNode } from "react";
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      {children}
+    </ThemeProvider>
+  );
+}


### PR DESCRIPTION
## ⚠️ This PR is broken as fuck

Dark mode implementation using `next-themes` + Tailwind v4 color variable overrides.

### What was attempted:
- Installed `next-themes` with `ThemeProvider` and `@custom-variant dark` for Tailwind v4
- Created `ThemeToggle` component in navbars (Student, Manager, Admin, Landing)
- Overrode Tailwind `--color-*` variables in `.dark` scope
- Replaced hardcoded `bg-[#EDE9DE]` with `bg-[var(--cream)]` globally

### What's broken:
- Many components still have hardcoded hex colors in `style={{}}` and arbitrary Tailwind values that don't flip
- Cards/containers inconsistently dark
- Text contrast issues on several pages
- Needs a full component-by-component audit before it's usable

Parking this for now. Do not merge.