### PR TITLE
fix(sys-dashboard): restore role prop for NotificationBell to fix type error

### DIFF
--- a/src/app/(main)/sys/(dashboard)/page.tsx
+++ b/src/app/(main)/sys/(dashboard)/page.tsx
@@ -334,8 +334,10 @@ export default function DashboardPage({
 
           {/* Notification bell */}
           <div className="relative">
+            {/* biome-ignore lint/a11y/useValidAriaRole: role is a custom react component prop */}
             <NotificationBell
               accountNumber={sysAccountNumber}
+              role="System Admin"
               logsHref="/sys/logs"
             />
           </div>


### PR DESCRIPTION
Restores the role prop that was incorrectly removed by Biome and adds an ignore comment to prevent it from happening again. This fixes the typecheck failure in Vercel.